### PR TITLE
Fix public charges wrongly tagged as wallbox sessions, auto-confirm charge type from station data

### DIFF
--- a/poller/recorder.py
+++ b/poller/recorder.py
@@ -214,8 +214,17 @@ class Recorder:
 
     def _read_wallbox_energy(self) -> Optional[float]:
         """Current wallbox kWh-counter reading from Home Assistant (best-effort, never raises).
-        Returns None when no wallbox is configured/reachable → the charge falls back to DC billing.
-        Reuses web/ha_client.get_live() (the same reader the web layer uses)."""
+        Returns None when no wallbox is configured/reachable, or when a mapped power sensor
+        proves the wallbox is idle right now (see below) → the charge falls back to DC billing.
+        Reuses web/ha_client.get_live() (the same reader the web layer uses).
+
+        A reachable wallbox always answers SOME energy-counter reading, even while the car is
+        charging elsewhere entirely (a public station, hundreds of km from home) — it's just
+        sitting there unused. Recording that reading used to seed the charge's wallbox baseline
+        regardless, permanently mislabelling a public charge as wallbox-billed. When a `power`
+        sensor is mapped, `charging` (power > 0.05 kW) tells the two apart: require it before
+        trusting the energy reading. Users who only mapped an energy sensor (no power role) have
+        nothing to verify against, so they keep the old best-effort behaviour."""
         try:
             import sys
             import pathlib
@@ -223,7 +232,10 @@ class Recorder:
             if web not in sys.path:
                 sys.path.insert(0, web)
             import ha_client
-            return ha_client.get_live().get("energy_kwh")
+            live = ha_client.get_live()
+            if ha_client.get_mapping().get("power") and not live.get("charging"):
+                return None
+            return live.get("energy_kwh")
         except Exception as e:  # noqa: BLE001
             log.debug("wallbox energy read failed: %s", e)
             return None

--- a/tests/test_charger_locator.py
+++ b/tests/test_charger_locator.py
@@ -56,7 +56,7 @@ def test_nearest_named_wins_over_anonymous_first(monkeypatch):
     els = [_node(1, 45.00004, 9.0),                              # ~5 m, anonymous
            _node(2, 45.00036, 9.0, operator="Ionity Binasco")]   # ~40 m, named
     monkeypatch.setattr(CL, "_query", lambda *a: els)
-    assert CL.find_station_name(45.0, 9.0) == ("Ionity Binasco", True)
+    assert CL.find_station_name(45.0, 9.0) == ("Ionity Binasco", None, True)
 
 
 def test_way_mapped_station_found(monkeypatch):
@@ -65,7 +65,7 @@ def test_way_mapped_station_found(monkeypatch):
     els = [{"type": "way", "id": 7, "center": {"lat": 45.0001, "lon": 9.0},
             "tags": {"name": "Supercharger Milano"}}]
     monkeypatch.setattr(CL, "_query", lambda *a: els)
-    assert CL.find_station_name(45.0, 9.0) == ("Supercharger Milano", True)
+    assert CL.find_station_name(45.0, 9.0) == ("Supercharger Milano", None, True)
 
 
 def test_label_tag_priority(monkeypatch):
@@ -76,11 +76,11 @@ def test_label_tag_priority(monkeypatch):
 
 def test_nothing_found_vs_network_error(monkeypatch):
     monkeypatch.setattr(CL, "_query", lambda *a: [])
-    assert CL.find_station_name(45.0, 9.0) == (None, True)    # OSM answered empty → sentinel
+    assert CL.find_station_name(45.0, 9.0) == (None, None, True)  # OSM answered empty → sentinel
     # Transient only when EVERY applicable source errors (OSM + the Italian PUN here).
     monkeypatch.setattr(CL, "_query", lambda *a: None)
     monkeypatch.setattr(CL, "_pun_stations", lambda *a, **k: None)
-    assert CL.find_station_name(45.0, 9.0) == (None, False)   # all dead → retry later
+    assert CL.find_station_name(45.0, 9.0) == (None, None, False)   # all dead → retry later
 
 
 # ── sweep: labels, sentinels, skips, reuse, abort ─────────────────────────────
@@ -94,13 +94,75 @@ def test_sweep_labels_and_sentinels(tmp_path, monkeypatch):
     calls = []
     def fake(lat, lon):
         calls.append((lat, lon))
-        return ("E-Moving", True) if lat == 45.0 else (None, True)
+        return ("E-Moving", None, True) if lat == 45.0 else (None, None, True)
     monkeypatch.setattr(CL, "find_station_name", fake)
     assert CL.sweep_now() == 1                       # one NAME found
     assert _row(pdb, 1)["location_name"] == "E-Moving"
     assert _row(pdb, 2)["location_name"] == ""       # looked up, nothing there
     assert len(calls) == 2
     assert CL.sweep_now() == 0 and len(calls) == 2   # fully resolved: no further calls
+
+
+def test_sweep_auto_confirms_unambiguous_type(tmp_path, monkeypatch):
+    """The station's own current+kW data, when unambiguous, fills in the AC/FAST/HPC
+    type too — skipping the manual 'confirm this charge' step, exactly the feature the
+    user asked for after the Fistra (MC) charge got stuck unlabelled AND unconfirmed."""
+    pdb = _setup(tmp_path, monkeypatch)
+    _charge(pdb, 1, lat=45.0, lon=9.0)     # location_type NULL — still unconfirmed
+    monkeypatch.setattr(CL, "find_station_name", lambda *a: ("Enel X Way", "HPC", True))
+    assert CL.sweep_now() == 1
+    row = _row(pdb, 1)
+    assert row["location_name"] == "Enel X Way"
+    assert row["location_type"] == "HPC"
+
+
+def test_sweep_does_not_override_an_already_confirmed_type(tmp_path, monkeypatch):
+    """Naming and confirming are independent: a charge the user already typed MANUAL
+    can still get its 📍 name, but auto-confirm must never overwrite that choice."""
+    pdb = _setup(tmp_path, monkeypatch)
+    _charge(pdb, 1, lat=45.0, lon=9.0, ctype="MANUAL")
+    monkeypatch.setattr(CL, "find_station_name", lambda *a: ("Enel X Way", "HPC", True))
+    assert CL.sweep_now() == 1
+    row = _row(pdb, 1)
+    assert row["location_name"] == "Enel X Way"   # still got named
+    assert row["location_type"] == "MANUAL"       # but the manual pick stands
+
+
+def test_sweep_leaves_ambiguous_type_unconfirmed(tmp_path, monkeypatch):
+    """A mixed AC/DC site (or a source with no current-type data) can't say which cable
+    THIS session used — the charge stays named but unconfirmed, same as before."""
+    pdb = _setup(tmp_path, monkeypatch)
+    _charge(pdb, 1, lat=45.0, lon=9.0)
+    monkeypatch.setattr(CL, "find_station_name", lambda *a: ("Ionity Hub", None, True))
+    assert CL.sweep_now() == 1
+    row = _row(pdb, 1)
+    assert row["location_name"] == "Ionity Hub"
+    assert row["location_type"] is None
+
+
+def test_sweep_reuse_path_does_not_guess_type(tmp_path, monkeypatch):
+    """The GPS-reuse shortcut (skips the network call) copies only the NAME, never a
+    type: the reused spot's own charge may have been typed by the user for unrelated
+    reasons (MANUAL/FREE/a correction), so propagating it would be a guess, not a fact."""
+    pdb = _setup(tmp_path, monkeypatch)
+    _charge(pdb, 1, lat=45.0, lon=9.0, name="Ionity Binasco", ctype="MANUAL")
+    _charge(pdb, 2, lat=45.00027, lon=9.0)                       # ~30 m away, unconfirmed
+    monkeypatch.setattr(CL, "find_station_name",
+                        lambda *a: (_ for _ in ()).throw(AssertionError("network hit")))
+    assert CL.sweep_now() == 1
+    row = _row(pdb, 2)
+    assert row["location_name"] == "Ionity Binasco"
+    assert row["location_type"] is None
+
+
+def test_classify_current():
+    assert CL._classify_current("AC", 22.0) == "AC"
+    assert CL._classify_current("AC", 0.0) == "AC"
+    assert CL._classify_current("DC", 50.0) == "FAST"
+    assert CL._classify_current("DC", 150.0) == "HPC"
+    assert CL._classify_current("DC", 0.0) == "FAST"     # unknown kW → the common default
+    assert CL._classify_current("AC/DC", 150.0) is None  # mixed site → ambiguous
+    assert CL._classify_current("", 0.0) is None         # source didn't say
 
 
 def test_sweep_skips_home_wallbox_open_and_nogps(tmp_path, monkeypatch):
@@ -136,7 +198,7 @@ def test_sweep_aborts_on_transient_error(tmp_path, monkeypatch):
     """Overpass down → stop the round, leave NULL so the next sweep retries."""
     pdb = _setup(tmp_path, monkeypatch)
     _charge(pdb, 1)
-    monkeypatch.setattr(CL, "find_station_name", lambda *a: (None, False))
+    monkeypatch.setattr(CL, "find_station_name", lambda *a: (None, None, False))
     assert CL.sweep_now() == 0
     assert _row(pdb, 1)["location_name"] is None
     assert db_reader.has_location_lookup_candidates()
@@ -234,6 +296,8 @@ def test_ocm_stations_parse(monkeypatch):
     assert [s["name"] for s in res] == ["BeCharge Lorenteggio", "Ionity Hub"]
     assert res[1]["info"] == "DC · 300 kW"                              # CurrentTypeID 30
     assert res[0]["info"] == "AC · 22 kW"                               # CurrentTypeID 20
+    assert res[1]["current"] == "DC" and res[1]["kw"] == 300.0
+    assert res[0]["current"] == "AC" and res[0]["kw"] == 22.0
 
 
 def test_ocm_keyless_is_silent_and_error_is_none(monkeypatch):
@@ -298,7 +362,7 @@ def test_label_sweep_never_uses_tomtom(monkeypatch):
     monkeypatch.setattr(CL, "_tomtom_stations",
                         lambda *a, **k: (_ for _ in ()).throw(AssertionError("TomTom in label path")))
     monkeypatch.setattr(CL, "_query", lambda *a: [_node(1, 45.0, 9.0, operator="A2A")])
-    assert CL.find_station_name(45.0, 9.0) == ("A2A", True)    # OSM name, no TomTom touched
+    assert CL.find_station_name(45.0, 9.0) == ("A2A", None, True)    # OSM name, no TomTom touched
 
 
 def test_find_nearby_merges_osm_and_ocm(monkeypatch):
@@ -344,12 +408,12 @@ def test_station_name_uses_ocm_and_osm_dead_rules(monkeypatch):
     monkeypatch.setattr(CL, "_ocm_stations",
                         lambda *a, **k: [{"name": "BeCharge", "lat": 45.0, "lon": 9.0,
                                           "dist_m": 60, "info": ""}])
-    assert CL.find_station_name(45.0, 9.0) == ("BeCharge", True)        # OCM name wins
+    assert CL.find_station_name(45.0, 9.0) == ("BeCharge", None, True)  # OCM name wins
     # every applicable source errors → retry (OSM None, OCM keyed+None, PUN None)
     monkeypatch.setattr(CL, "_ocm_key", lambda: "k")
     monkeypatch.setattr(CL, "_ocm_stations", lambda *a, **k: None)
     monkeypatch.setattr(CL, "_pun_stations", lambda *a, **k: None)
-    assert CL.find_station_name(45.0, 9.0) == (None, False)
+    assert CL.find_station_name(45.0, 9.0) == (None, None, False)
 
 
 # ── PUN — Piattaforma Unica Nazionale (Italy, keyless, referer-gated) ─────────
@@ -383,6 +447,8 @@ def test_pun_groups_connectors_and_reads_status(monkeypatch):
     assert by["Atlante"]["avail"] == "1/2"          # one AVAILABLE of two connectors
     assert by["A2A"]["info"] == "AC · 22 kW"
     assert by["A2A"]["avail"] == "1/1"
+    assert by["Atlante"]["current"] == "DC" and by["Atlante"]["kw"] == 60.0
+    assert by["A2A"]["current"] == "AC" and by["A2A"]["kw"] == 22.0
 
 
 def test_pun_skipped_outside_italy(monkeypatch):

--- a/tests/test_wallbox_misattribution_guard.py
+++ b/tests/test_wallbox_misattribution_guard.py
@@ -1,0 +1,125 @@
+"""A public charge must never be mislabelled as a home-wallbox session (PR #147 follow-up,
+GitHub issue from @arch.gamberoni: an Enel X charge in Fistra (MC) never got its 📍 station
+name because the poller had seeded `wallbox_energy_start_kwh` from the home wallbox's idle
+energy-counter reading, even though the car was charging hundreds of km away).
+
+Two independent guards:
+  1. poller/recorder.py._read_wallbox_energy — only trust the energy reading when a mapped
+     `power` sensor confirms the wallbox is ACTIVELY delivering power right now; a reachable-
+     but-idle wallbox no longer poisons a charge that isn't actually happening on it.
+  2. web/db_reader.update_charge_type — retyping a charge away from HOME clears the wallbox
+     fields, so a charge the user corrects (or that was already stuck from before guard #1
+     existed) becomes eligible again for the 📍 charging-station lookup.
+
+CI-safe: pure recorder/db_reader logic, no fastapi, no network.
+"""
+import db as D             # poller schema (creates charges/settings tables + migrations)
+import db_reader
+import recorder as R
+
+
+# ── guard 1: the poller no longer trusts an idle wallbox's stale reading ─────────
+
+def _recorder():
+    db = D.Database(":memory:")
+    db._conn.execute("INSERT INTO vehicles (id, vin) VALUES (1, 'V')")
+    db._conn.commit()
+    return R.Recorder(db, vehicle_id=1)
+
+
+def test_idle_wallbox_with_power_sensor_is_not_trusted(monkeypatch):
+    """Power sensor mapped and reads ~0 (car charging elsewhere) → energy reading discarded."""
+    import ha_client
+    monkeypatch.setattr(ha_client, "get_mapping", lambda: {"power": "sensor.wb_power"})
+    monkeypatch.setattr(ha_client, "get_live",
+                         lambda: {"energy_kwh": 1234.5, "power_kw": 0.0, "charging": False})
+    rec = _recorder()
+    assert rec._read_wallbox_energy() is None
+
+
+def test_active_wallbox_with_power_sensor_is_trusted(monkeypatch):
+    """Power sensor mapped and reads real power (genuine home charge) → energy reading kept."""
+    import ha_client
+    monkeypatch.setattr(ha_client, "get_mapping", lambda: {"power": "sensor.wb_power"})
+    monkeypatch.setattr(ha_client, "get_live",
+                         lambda: {"energy_kwh": 1234.5, "power_kw": 7.4, "charging": True})
+    rec = _recorder()
+    assert rec._read_wallbox_energy() == 1234.5
+
+
+def test_no_power_sensor_mapped_keeps_old_best_effort_behaviour(monkeypatch):
+    """No power role mapped (only energy) → nothing to verify against → unchanged behaviour."""
+    import ha_client
+    monkeypatch.setattr(ha_client, "get_mapping", lambda: {"energy": "sensor.wb_energy"})
+    monkeypatch.setattr(ha_client, "get_live",
+                         lambda: {"energy_kwh": 42.0, "power_kw": None, "charging": False})
+    rec = _recorder()
+    assert rec._read_wallbox_energy() == 42.0
+
+
+def test_recorder_does_not_seed_baseline_from_an_idle_wallbox(monkeypatch):
+    """End-to-end: a charge opened while the home wallbox is reachable-but-idle must not get a
+    wallbox baseline — the exact scenario that stuck the Fistra charge with no 📍 name forever."""
+    import ha_client
+    monkeypatch.setattr(ha_client, "get_mapping", lambda: {"power": "sensor.wb_power"})
+    monkeypatch.setattr(ha_client, "get_live",
+                         lambda: {"energy_kwh": 500.0, "power_kw": 0.0, "charging": False})
+    from client import _parse_signal
+
+    rec = _recorder()
+    rec.process(_parse_signal("V", {"1010": 0, "1319": 0, "100003": 55}))            # parked
+    rec.process(_parse_signal("V", {"1010": 0, "1319": 0, "100003": 55,
+                                     "1149": 2, "1178": 16, "1177": 230}))            # charging
+    assert rec._active_charge_id is not None
+    row = rec._db._conn.execute(
+        "SELECT wallbox_energy_start_kwh, ac_energy_kwh FROM charges WHERE id=?",
+        (rec._active_charge_id,)).fetchone()
+    assert row["wallbox_energy_start_kwh"] is None
+    assert row["ac_energy_kwh"] in (None, 0)
+
+
+# ── guard 2: retyping away from HOME clears the wallbox fields ──────────────────
+
+def _setup(tmp_path, monkeypatch):
+    pdb = D.Database(str(tmp_path / "t.db"))
+    monkeypatch.setattr(db_reader, "DB_PATH", str(tmp_path / "t.db"))
+    return pdb
+
+
+def _charge(pdb, cid, *, lat=43.039036, lon=13.166765, ctype="AC", ac=0.0, wb_start=0.0):
+    pdb._conn.execute(
+        "INSERT INTO charges (id, vehicle_id, started_at, ended_at, start_soc, end_soc,"
+        " energy_added_kwh, latitude, longitude, location_type, ac_energy_kwh,"
+        " wallbox_energy_start_kwh)"
+        " VALUES (?,1,'2026-07-18T15:27:18+00:00','2026-07-18T16:31:51+00:00',49.7,64.5,"
+        "9.9,?,?,?,?,?)",
+        (cid, lat, lon, ctype, ac, wb_start))
+    pdb._conn.commit()
+
+
+def test_retag_away_from_home_clears_wallbox_fields(tmp_path, monkeypatch):
+    pdb = _setup(tmp_path, monkeypatch)
+    _charge(pdb, 1, ctype="AC", wb_start=0.0)
+    out = db_reader.update_charge_type(1, "AC")
+    assert out["wallbox_energy_start_kwh"] is None
+    assert out["ac_energy_kwh"] is None
+
+
+def test_retag_to_home_keeps_wallbox_fields(tmp_path, monkeypatch):
+    pdb = _setup(tmp_path, monkeypatch)
+    _charge(pdb, 1, ctype="AC", wb_start=12.3, ac=4.2)
+    out = db_reader.update_charge_type(1, "HOME")
+    assert out["wallbox_energy_start_kwh"] == 12.3
+    assert out["ac_energy_kwh"] == 4.2
+
+
+def test_retagged_charge_becomes_a_location_lookup_candidate(tmp_path, monkeypatch):
+    """The whole point of guard 2: after the retag, the charge is no longer excluded by
+    _LOCATION_CANDIDATES_WHERE and can get its 📍 station name resolved."""
+    pdb = _setup(tmp_path, monkeypatch)
+    _charge(pdb, 1, ctype="AC", wb_start=0.0)
+    assert db_reader.has_location_lookup_candidates() is False   # stuck, as reported
+    db_reader.update_charge_type(1, "AC")
+    assert db_reader.has_location_lookup_candidates() is True
+    cands = db_reader.get_location_lookup_candidates()
+    assert [c["id"] for c in cands] == [1]

--- a/web/charger_locator.py
+++ b/web/charger_locator.py
@@ -5,6 +5,11 @@ Two consumers:
     closed charge (shown on the Charges list and the Overview "last charge" card).
     Opt-in via the `charger_locator` setting — home charges are never looked up, and
     history backfills too (charges already store their GPS position since v1.0).
+    When the winning station's own data unambiguously says AC or DC (+ kW), the sweep
+    also auto-fills the charge's AC/FAST/HPC type — skipping the manual "confirm this
+    charge" step — but only on a charge still unconfirmed (`location_type IS NULL`),
+    and never on a mixed AC/DC site (knowing the site exists doesn't say which cable
+    this session used).
   - Navigation page: "Find charging stations" around the car, user-picked radius.
 
 Keyless and free (no API key), same etiquette as geocode.py: proper User-Agent,
@@ -83,15 +88,11 @@ def _fmt_kw(kw: float) -> str:
     return f"{round(kw)}" if kw >= 20 else f"{round(kw, 1):g}"
 
 
-def _socket_info(tags: dict) -> str:
-    """Best-effort 'DC · CCS · 300 kW' summary from the community socket:* /
-    maxoutput tags (sparsely mapped — empty string when nothing usable).
-    AC/DC is inferred: CCS/CHAdeMO sockets → DC, Type 2 → AC, and a max output
-    ≥ 50 kW implies DC even when the socket tags are missing."""
-    kinds = []
-    for key, label in _SOCKETS:
-        if _has(tags, key) and label not in kinds:
-            kinds.append(label)
+def _socket_current_kw(tags: dict):
+    """(current, kw) from the community socket:*/maxoutput tags (sparsely mapped —
+    '' / 0.0 when nothing usable). AC/DC is inferred: CCS/CHAdeMO sockets → DC,
+    Type 2 → AC, and a max output ≥ 50 kW implies DC even when the socket tags
+    are missing."""
     kw = 0.0
     for k, v in tags.items():
         if k == "maxoutput" or (k.startswith("socket:") and k.endswith(":output")):
@@ -101,10 +102,34 @@ def _socket_info(tags: dict) -> str:
     dc = any(_has(tags, k) for k in _DC_SOCKETS) or kw >= 50
     ac = any(_has(tags, k) for k in _AC_SOCKETS)
     current = "AC/DC" if (ac and dc) else "DC" if dc else "AC" if ac else ""
+    return current, kw
+
+
+def _socket_info(tags: dict) -> str:
+    """Best-effort 'DC · CCS · 300 kW' summary from the community socket:* /
+    maxoutput tags (sparsely mapped — empty string when nothing usable)."""
+    kinds = []
+    for key, label in _SOCKETS:
+        if _has(tags, key) and label not in kinds:
+            kinds.append(label)
+    current, kw = _socket_current_kw(tags)
     parts = ([current] if current else []) + kinds
     if kw:
         parts.append(f"{_fmt_kw(kw)} kW")
     return " · ".join(parts)
+
+
+def _classify_current(current: str, kw: float):
+    """Best-effort AC/FAST/HPC guess from a station's current type + kW, for the 📍
+    sweep's auto-confirm — None when ambiguous (a mixed AC/DC site, or the source
+    didn't say): the app's 4-way HOME/AC/FAST/HPC split needs to know which cable a
+    session actually used, and a mixed site alone can't tell you that. The 80 kW
+    DC/HPC cutoff mirrors `db_reader.auto_location_type`, for consistency."""
+    if current == "AC":
+        return "AC"
+    if current == "DC":
+        return "HPC" if kw and kw > 80 else "FAST"
+    return None
 
 
 def _query(lat: float, lon: float, radius_m: int, limit: int, tries: int = 2):
@@ -141,13 +166,16 @@ def _query(lat: float, lon: float, radius_m: int, limit: int, tries: int = 2):
 
 
 def find_station_name(lat: float, lon: float):
-    """(name | None, ok). ok=False → transient error, worth retrying later;
-    ok=True with None → genuinely nothing usable within _LABEL_RADIUS_M.
-    Union of OSM and (when a key is set) Open Charge Map, picking the NEAREST entry
-    that HAS a name: Overpass returns by id (not distance) and unnamed stall nodes
-    commonly sit next to the named site POI."""
+    """(name | None, location_type | None, ok). ok=False → transient error, worth
+    retrying later; ok=True with name=None → genuinely nothing usable within
+    _LABEL_RADIUS_M. Union of OSM and (when a key is set) Open Charge Map, picking
+    the NEAREST entry that HAS a name: Overpass returns by id (not distance) and
+    unnamed stall nodes commonly sit next to the named site POI.
+    location_type is `_classify_current`'s AC/FAST/HPC guess from that SAME winning
+    candidate's own current/kW data — None when it didn't say, or said something
+    ambiguous."""
     if not lat or not lon:
-        return None, True
+        return None, None, True
     els = _query(lat, lon, _LABEL_RADIUS_M, 10)
     ocm = _ocm_stations(lat, lon, _LABEL_RADIUS_M, 5)
     pun = _pun_stations(lat, lon, _LABEL_RADIUS_M, 20)
@@ -156,18 +184,22 @@ def find_station_name(lat: float, lon: float):
         la, lo = _coord(e)
         if la is None:
             continue
-        cands.append((_dist_m(lat, lon, la, lo), _label(e.get("tags", {}))))
-    cands.extend((s["dist_m"], s["name"]) for s in (ocm or []))
-    cands.extend((s["dist_m"], s["name"]) for s in (pun or []))
+        tags = e.get("tags", {})
+        current, kw = _socket_current_kw(tags)
+        cands.append((_dist_m(lat, lon, la, lo), _label(tags), current, kw))
+    cands.extend((s["dist_m"], s["name"], s.get("current", ""), s.get("kw", 0.0))
+                 for s in (ocm or []))
+    cands.extend((s["dist_m"], s["name"], s.get("current", ""), s.get("kw", 0.0))
+                 for s in (pun or []))
     cands.sort(key=lambda c: c[0])
-    for _d, label in cands:
+    for _d, label, current, kw in cands:
         if label:
-            return label, True
+            return label, _classify_current(current, kw), True
     # No name found: that verdict is final only if at least one source actually
     # answered — if every source we tried errored, stay NULL and retry next sweep.
     tried = [els, ocm if _ocm_key() else None, pun if _in_italy(lat, lon) else None]
     answered = any(r is not None for r in tried)
-    return None, answered
+    return None, None, answered
 
 
 def find_nearby(lat: float, lon: float, radius_m: int, limit: int = 25, name_filter: str = ""):
@@ -273,11 +305,12 @@ def _ocm_stations(lat: float, lon: float, radius_m: int, limit: int = 100):
         kw = max((c.get("PowerKW") or 0) for c in conns) if conns else 0
         cur = sorted({_OCM_CUR[c["CurrentTypeID"]] for c in conns
                       if _OCM_CUR.get(c.get("CurrentTypeID"))})
+        current = "AC/DC" if len(cur) > 1 else (cur[0] if cur else "")
         parts = (["/".join(cur)] if cur else []) + ([f"{_fmt_kw(kw)} kW"] if kw else [])
         name = ((a.get("Title") or "").strip()
                 or ((p.get("OperatorInfo") or {}).get("Title") or "").strip() or None)
         out.append({"name": name, "lat": la, "lon": lo, "dist_m": int(d),
-                    "info": " · ".join(parts)})
+                    "info": " · ".join(parts), "current": current, "kw": kw})
     return out
 
 
@@ -498,7 +531,8 @@ def _pun_parse(lat: float, lon: float, feats: list) -> list:
         la0, lo0 = a0["Latitudine_EVSE"], a0["Longitudine_EVSE"]
         out.append({"name": name, "lat": la0, "lon": lo0,
                     "dist_m": int(_dist_m(lat, lon, la0, lo0)),
-                    "info": info, "avail": f"{avail}/{len(conns)}"})
+                    "info": info, "avail": f"{avail}/{len(conns)}",
+                    "current": cur, "kw": kw})
     return out
 
 
@@ -561,7 +595,7 @@ def _sweep_body(limit: int) -> int:
             continue
         if called:
             time.sleep(1.0)  # Overpass etiquette between consecutive calls
-        name, ok = find_station_name(lat, lon)
+        name, ctype, ok = find_station_name(lat, lon)
         called = True
         if not ok:  # Overpass down/rate-limited: stop here, leftovers retry next sweep
             log.info("charger locator: Overpass unreachable — will retry next sweep")
@@ -572,4 +606,11 @@ def _sweep_body(limit: int) -> int:
         if name:
             named += 1
             log.info("charger locator: charge #%s → %s", c["id"], name)
+            # Auto-confirm AC/FAST/HPC from the station's own data, but only when the
+            # charge is still unconfirmed — never override a manual pick (MANUAL/FREE/
+            # a type the user already corrected), even though such charges can still be
+            # 📍-lookup candidates (naming and confirming are independent).
+            if ctype and c.get("location_type") is None:
+                db_reader.update_charge_type(c["id"], ctype)
+                log.info("charger locator: charge #%s auto-confirmed → %s", c["id"], ctype)
     return named

--- a/web/db_reader.py
+++ b/web/db_reader.py
@@ -1090,10 +1090,21 @@ def update_charge_type(charge_id: int, location_type: str,
         billed = meter if (location_type == "HOME" and meter and meter > 0) else None
         cost = compute_cost(charge, ac_kwh=billed)   # returns 0.0 when the charge is marked free
 
-    db.execute(
-        "UPDATE charges SET location_type=?, cost=?, is_free=? WHERE id=?",
-        (location_type, cost, free, charge_id)
-    )
+    if location_type != "HOME":
+        # A charge re-typed away from HOME didn't happen on the wallbox the poller seeded these
+        # from (a stale/misattributed reading — see the 📍 charging-station lookup bug: those two
+        # columns being non-NULL is what marks a charge as "wallbox session", permanently excluding
+        # it from _LOCATION_CANDIDATES_WHERE). Drop them so the charge becomes eligible again.
+        db.execute(
+            "UPDATE charges SET location_type=?, cost=?, is_free=?, "
+            "wallbox_energy_start_kwh=NULL, ac_energy_kwh=NULL WHERE id=?",
+            (location_type, cost, free, charge_id)
+        )
+    else:
+        db.execute(
+            "UPDATE charges SET location_type=?, cost=?, is_free=? WHERE id=?",
+            (location_type, cost, free, charge_id)
+        )
     db.commit()
     return dict(db.execute("SELECT * FROM charges WHERE id=?", (charge_id,)).fetchone())
 
@@ -1175,10 +1186,14 @@ def has_location_lookup_candidates() -> bool:
 
 
 def get_location_lookup_candidates(limit: int = 40) -> list[dict]:
+    """`location_type` is included so the sweep can tell an unconfirmed charge (safe to
+    auto-type from the station's own data) from one the user already picked a type for
+    (never override it — naming and confirming are independent, so a MANUAL/FREE/AC/FAST/
+    HPC charge can still be a candidate here for its 📍 name alone)."""
     try:
         rows = _get().execute(
-            f"SELECT id, latitude, longitude FROM charges WHERE vehicle_id = COALESCE(?, vehicle_id) "
-            f"AND {_LOCATION_CANDIDATES_WHERE} "
+            f"SELECT id, latitude, longitude, location_type FROM charges "
+            f"WHERE vehicle_id = COALESCE(?, vehicle_id) AND {_LOCATION_CANDIDATES_WHERE} "
             "ORDER BY started_at DESC LIMIT ?", (_current_vehicle_id(), limit)).fetchall()
     except sqlite3.Error:
         return []


### PR DESCRIPTION
Split out from the elevation-profile branch (#? — see maintainer's note there) so it can be reviewed on its own, since it touches charge-type classification.

## What this fixes

A closed public charge was permanently excluded from the 📍 charging-station-name lookup whenever the poller had seeded `wallbox_energy_start_kwh` from the home wallbox — which happened even while the car charged far away, since a reachable wallbox always answers some (stale) energy-counter reading.

Two guards:
- `poller/recorder.py` now requires a mapped power sensor to confirm the wallbox is actually delivering power before trusting its reading.
- Re-typing a charge away from HOME (`web/db_reader.py`) clears the stale wallbox fields so it becomes eligible again for the station lookup.

## What this adds

The 📍 sweep already computes AC/DC current + kW for the station it finds (`web/charger_locator.py`) but discarded it after building a display string. It now surfaces that data and, when unambiguous, auto-fills the charge's AC/FAST/HPC type — skipping the manual "confirm this charge" step — without ever overriding a type the user already picked.

## Test plan

- [x] `tests/test_wallbox_misattribution_guard.py` (new, 7 tests)
- [x] Full suite passes on top of current `main` (v2.8.0): 860 passed
