### PR TITLE
Add 100% estimated range to overview

### DIFF
--- a/web/locales/de.json
+++ b/web/locales/de.json
@@ -329,6 +329,7 @@
     "state_charge_complete": "Laden abgeschlossen",
     "battery": "Batterie",
     "range": "Reichweite",
+    "range_est_100": "Schätzung bei 100%",
     "state": "Status",
     "speed": "Tempo",
     "gear": "Gang",

--- a/web/locales/en.json
+++ b/web/locales/en.json
@@ -383,6 +383,7 @@
     "state_charge_complete": "Charge complete",
     "battery": "Battery",
     "range": "Range",
+    "range_est_100": "Estimated at 100%",
     "state": "State",
     "speed": "Speed",
     "gear": "Gear",

--- a/web/locales/fr.json
+++ b/web/locales/fr.json
@@ -383,6 +383,7 @@
     "state_charge_complete": "Charge terminée",
     "battery": "Batterie",
     "range": "Autonomie",
+    "range_est_100": "Estimation à 100 %",
     "state": "État",
     "speed": "Vitesse",
     "gear": "Rapport",

--- a/web/locales/it.json
+++ b/web/locales/it.json
@@ -383,6 +383,7 @@
     "state_charge_complete": "Carica completa",
     "battery": "Batteria",
     "range": "Autonomia",
+    "range_est_100": "Stima al 100%",
     "state": "Stato",
     "speed": "Velocità",
     "gear": "Marcia",

--- a/web/locales/pl.json
+++ b/web/locales/pl.json
@@ -318,6 +318,7 @@
     "state_charge_complete": "Ładowanie zakończone",
     "battery": "Bateria",
     "range": "Zasięg",
+    "range_est_100": "Szacunek przy 100%",
     "state": "Stan",
     "speed": "Prędkość",
     "gear": "Bieg",

--- a/web/locales/pt-PT.json
+++ b/web/locales/pt-PT.json
@@ -383,6 +383,7 @@
     "state_charge_complete": "Carregamento concluído",
     "battery": "Bateria",
     "range": "Autonomia",
+    "range_est_100": "Estimativa a 100%",
     "state": "Estado",
     "speed": "Velocidade",
     "gear": "Mudança",

--- a/web/templates/partials/status_card.html
+++ b/web/templates/partials/status_card.html
@@ -2,16 +2,26 @@
 {% set soc = status.soc or 0 %}
 {% set color = soc_color(soc) %}
 {% set state = state_label(status) %}
+{% set est_full_range_km = (status.range_km / soc * 100) if status.range_km is not none and soc > 0 else none %}
 
 <!-- SOC + Range -->
-<div class="flex items-end justify-between mb-4">
-  <div>
-    <div class="stat-label">{{ t('battery') }}</div>
-    <div class="text-5xl font-bold" style="color:{{ color }}">{{ "%.1f"|format(soc) }}<span class="text-2xl text-slate-400">%</span></div>
-  </div>
-  <div class="text-right">
-    <div class="stat-label">{{ t('range') }}</div>
-    <div class="stat-value">{{ dist_val(status.range_km)|int }} <span class="text-base font-normal text-slate-400">{{ dist_unit() }}</span></div>
+<div class="mb-4">
+  <div class="grid grid-cols-2 items-start gap-4">
+    <div class="text-left">
+      <div class="stat-label">{{ t('battery') }}</div>
+      <div class="text-5xl font-bold leading-none" style="color:{{ color }}">{{ "%.1f"|format(soc) }}<span class="text-2xl text-slate-400">%</span></div>
+    </div>
+    <div class="text-right flex flex-col items-end">
+      <div class="stat-label">{{ t('range') }}</div>
+      <div class="stat-value leading-none mt-1">{{ dist_val(status.range_km)|int }} <span class="text-base font-normal text-slate-400">{{ dist_unit() }}</span></div>
+      {% if est_full_range_km is not none %}
+      <div class="mt-0 text-[11px] leading-none">
+        <span class="text-slate-400">{{ t('range_est_100') }}:</span>
+        <span class="font-semibold text-teal-300">{{ dist_val(est_full_range_km)|int }}</span>
+        <span class="text-slate-400">{{ dist_unit() }}</span>
+      </div>
+      {% endif %}
+    </div>
   </div>
 </div>
 


### PR DESCRIPTION
This adds a 100% estimated range line in the Overview status card, computed from current battery percentage and displayed range. It also refines alignment and spacing for a cleaner visual balance, and adds locale strings for the new label across supported languages.