### PR TITLE
Replace year/month/day accordions with calendar and search functionality

### DIFF
--- a/tests/test_charges_calendar_search.py
+++ b/tests/test_charges_calendar_search.py
@@ -203,3 +203,25 @@ def test_charges_search_with_text_returns_flat_results(tmp_path, monkeypatch):
     body = resp.body.decode()
     assert 'data-charge-id="1"' in body
     assert 'id="charges-calendar-month"' not in body        # a flat list, not the calendar shell
+
+
+def test_charges_search_empty_numeric_fields_dont_422(tmp_path, monkeypatch):
+    """#175: an unfilled advanced-filter number input still submits its name with an EMPTY
+    value (cost_min=""), which a bare `float | None` FastAPI param 422s trying to parse —
+    htmx then silently does nothing (no 2xx response to swap in). Only `type` set, every
+    numeric field an empty string exactly as the real browser form submits them."""
+    pytest.importorskip("fastapi", reason="web.main needs fastapi (absent in the minimal CI test env)")
+    import main
+    pdb = _setup(tmp_path, monkeypatch)
+    monkeypatch.setattr(main.db_reader, "DB_PATH", str(tmp_path / "t.db"))
+    monkeypatch.setattr(main.db_reader, "get_language", lambda: "en")
+    _seed(pdb, 1, "2026-07-04T10:00:00+00:00", location_type="HPC")
+    _seed(pdb, 2, "2026-07-05T10:00:00+00:00", location_type="AC")
+
+    resp = asyncio.run(main.charges_search(
+        _Req(), type="HPC", cost_min="", cost_max="", kwh_min="", kwh_max="",
+        date_from="", date_to=""))
+    assert resp.status_code == 200
+    body = resp.body.decode()
+    assert 'data-charge-id="1"' in body
+    assert 'data-charge-id="2"' not in body

--- a/tests/test_charges_calendar_search.py
+++ b/tests/test_charges_calendar_search.py
@@ -1,0 +1,205 @@
+"""Charges 'calendar' Month view + search — replaces the old year/month/day accordion (still
+used nowhere else) with a lean month grid (day totals only, no per-charge markup until a day is
+clicked) plus a text+advanced-filter search that falls back to the calendar when cleared.
+Runs on a tmp_path DB (poller schema), CI-safe."""
+import asyncio
+
+import pytest
+
+import db as D
+import db_reader
+
+
+def _setup(tmp_path, monkeypatch):
+    pdb = D.Database(str(tmp_path / "t.db"))
+    monkeypatch.setattr(db_reader, "DB_PATH", str(tmp_path / "t.db"))
+    return pdb
+
+
+def _seed(pdb, cid, started, *, lat=45.0, lon=9.0, kwh=10.0, cost=None, name=None,
+          note=None, location_type=None, ended=None):
+    pdb._conn.execute(
+        "INSERT INTO charges (id, vehicle_id, started_at, ended_at, start_soc, end_soc,"
+        " energy_added_kwh, latitude, longitude, cost, location_name, note, location_type)"
+        " VALUES (?,1,?,?,30,80,?,?,?,?,?,?,?)",
+        (cid, started, ended or started, kwh, lat, lon, cost, name, note, location_type))
+    pdb._conn.commit()
+
+
+# ── get_charges_calendar_month: per-day totals ────────────────────────────────
+
+def test_calendar_month_day_totals(tmp_path, monkeypatch):
+    pdb = _setup(tmp_path, monkeypatch)
+    _seed(pdb, 1, "2026-07-04T10:00:00+00:00", kwh=10, cost=5)
+    _seed(pdb, 2, "2026-07-04T14:00:00+00:00", kwh=20, cost=8)
+    _seed(pdb, 3, "2026-07-10T10:00:00+00:00", kwh=15)                 # no cost
+    _seed(pdb, 4, "2026-08-01T10:00:00+00:00", kwh=5)                  # different month
+
+    cal = db_reader.get_charges_calendar_month(2026, 7)
+    assert cal["year"] == 2026 and cal["month"] == 7
+    assert cal["days"][4] == {"count": 2, "kwh": 30.0, "cost": 13.0, "has_cost": True}
+    assert cal["days"][10] == {"count": 1, "kwh": 15.0, "cost": 0.0, "has_cost": False}
+    assert 1 not in cal["days"]                                        # August charge excluded
+    assert cal["total"] == {"count": 3, "kwh": 45.0, "cost": 13.0, "has_cost": True}
+
+
+def test_calendar_month_empty(tmp_path, monkeypatch):
+    _setup(tmp_path, monkeypatch)
+    cal = db_reader.get_charges_calendar_month(2026, 7)
+    assert cal["days"] == {}
+    assert cal["total"]["count"] == 0
+
+
+def test_calendar_month_station_filter(tmp_path, monkeypatch):
+    """Same 'lat,lon' key convention as get_charges_grouped(station=...) — only that one
+    physical station's sessions count toward the month's day totals."""
+    pdb = _setup(tmp_path, monkeypatch)
+    _seed(pdb, 1, "2026-07-04T10:00:00+00:00", lat=45.070, lon=7.686, kwh=10)
+    _seed(pdb, 2, "2026-07-04T14:00:00+00:00", lat=46.000, lon=8.000, kwh=20)
+    cal = db_reader.get_charges_calendar_month(2026, 7, station="45.070,7.686")
+    assert cal["days"][4]["count"] == 1
+    assert cal["days"][4]["kwh"] == 10.0
+
+
+# ── get_charges_calendar_day: the day-drawer's charge list ───────────────────
+
+def test_calendar_day_charges_most_recent_first(tmp_path, monkeypatch):
+    pdb = _setup(tmp_path, monkeypatch)
+    _seed(pdb, 1, "2026-07-04T10:00:00+00:00", name="Enel X")
+    _seed(pdb, 2, "2026-07-04T18:00:00+00:00", name="Ionity")
+    _seed(pdb, 3, "2026-07-10T10:00:00+00:00", name="Elsewhere")   # different day
+    charges = db_reader.get_charges_calendar_day(2026, 7, 4)
+    assert [c["location_name"] for c in charges] == ["Ionity", "Enel X"]
+
+
+def test_calendar_day_no_charges_is_empty(tmp_path, monkeypatch):
+    _setup(tmp_path, monkeypatch)
+    assert db_reader.get_charges_calendar_day(2026, 7, 4) == []
+
+
+# ── search_charges: text + advanced filters ───────────────────────────────────
+
+def test_search_text_matches_name_or_note(tmp_path, monkeypatch):
+    pdb = _setup(tmp_path, monkeypatch)
+    _seed(pdb, 1, "2026-07-04T10:00:00+00:00", name="Ionity Binasco")
+    _seed(pdb, 2, "2026-07-05T10:00:00+00:00", name="Enel X", note="great spot near Ionity shop")
+    _seed(pdb, 3, "2026-07-06T10:00:00+00:00", name="BeCharge")
+    res = db_reader.search_charges(text="ionity")
+    assert {c["id"] for c in res} == {1, 2}          # name match + note match, case-insensitive
+
+
+def test_search_by_charge_type(tmp_path, monkeypatch):
+    pdb = _setup(tmp_path, monkeypatch)
+    _seed(pdb, 1, "2026-07-04T10:00:00+00:00", location_type="HOME")
+    _seed(pdb, 2, "2026-07-05T10:00:00+00:00", location_type="HPC")
+    res = db_reader.search_charges(charge_type="HPC")
+    assert [c["id"] for c in res] == [2]
+
+
+def test_search_kwh_and_cost_range(tmp_path, monkeypatch):
+    pdb = _setup(tmp_path, monkeypatch)
+    _seed(pdb, 1, "2026-07-04T10:00:00+00:00", kwh=10, cost=5)
+    _seed(pdb, 2, "2026-07-05T10:00:00+00:00", kwh=40, cost=25)
+    assert [c["id"] for c in db_reader.search_charges(kwh_min=20)] == [2]
+    assert [c["id"] for c in db_reader.search_charges(kwh_max=20)] == [1]
+    assert [c["id"] for c in db_reader.search_charges(cost_min=10, cost_max=30)] == [2]
+
+
+def test_search_date_range_is_inclusive_local_dates(tmp_path, monkeypatch):
+    pdb = _setup(tmp_path, monkeypatch)
+    _seed(pdb, 1, "2026-07-04T10:00:00+00:00")
+    _seed(pdb, 2, "2026-07-10T10:00:00+00:00")
+    _seed(pdb, 3, "2026-07-20T10:00:00+00:00")
+    res = db_reader.search_charges(date_from="2026-07-04", date_to="2026-07-10")
+    assert {c["id"] for c in res} == {1, 2}
+
+
+def test_search_no_filters_returns_full_history_most_recent_first(tmp_path, monkeypatch):
+    pdb = _setup(tmp_path, monkeypatch)
+    _seed(pdb, 1, "2026-07-04T10:00:00+00:00")
+    _seed(pdb, 2, "2026-07-05T10:00:00+00:00")
+    assert [c["id"] for c in db_reader.search_charges()] == [2, 1]
+
+
+def test_search_station_filter(tmp_path, monkeypatch):
+    pdb = _setup(tmp_path, monkeypatch)
+    _seed(pdb, 1, "2026-07-04T10:00:00+00:00", lat=45.070, lon=7.686)
+    _seed(pdb, 2, "2026-07-05T10:00:00+00:00", lat=46.000, lon=8.000)
+    res = db_reader.search_charges(station="45.070,7.686")
+    assert [c["id"] for c in res] == [1]
+
+
+# ── get_charge_years: populates the calendar's year-jump pills ────────────────
+
+def test_charge_years_distinct_descending(tmp_path, monkeypatch):
+    pdb = _setup(tmp_path, monkeypatch)
+    _seed(pdb, 1, "2024-03-01T10:00:00+00:00")
+    _seed(pdb, 2, "2026-07-04T10:00:00+00:00")
+    _seed(pdb, 3, "2026-07-05T10:00:00+00:00")   # same year as #2, must not duplicate
+    assert db_reader.get_charge_years() == [2026, 2024]
+
+
+def test_charge_years_empty_when_no_charges(tmp_path, monkeypatch):
+    _setup(tmp_path, monkeypatch)
+    assert db_reader.get_charge_years() == []
+
+
+def test_charge_years_station_filter(tmp_path, monkeypatch):
+    pdb = _setup(tmp_path, monkeypatch)
+    _seed(pdb, 1, "2024-03-01T10:00:00+00:00", lat=45.070, lon=7.686)
+    _seed(pdb, 2, "2026-07-04T10:00:00+00:00", lat=46.000, lon=8.000)
+    assert db_reader.get_charge_years(station="45.070,7.686") == [2024]
+
+
+# ── today_local / get_charge_local_date — the ?highlight= month-resolving helpers ────
+
+def test_today_local_is_a_real_date(tmp_path, monkeypatch):
+    _setup(tmp_path, monkeypatch)
+    today = db_reader.today_local()
+    assert today.year >= 2026
+
+
+def test_get_charge_local_date_resolves_and_missing_is_none(tmp_path, monkeypatch):
+    pdb = _setup(tmp_path, monkeypatch)
+    _seed(pdb, 1, "2026-07-04T10:00:00+00:00")
+    d = db_reader.get_charge_local_date(1)
+    assert (d.year, d.month, d.day) == (2026, 7, 4)
+    assert db_reader.get_charge_local_date(999) is None
+
+
+# ── main.py wiring: the empty-search fallback and the calendar/day endpoints ─────────
+
+class _Req:
+    """Minimal Starlette Request stand-in — these endpoints only read query params
+    (already bound by FastAPI) and pass `request` straight to TemplateResponse."""
+
+
+def test_charges_search_falls_back_to_calendar_when_all_filters_empty(tmp_path, monkeypatch):
+    """No text, no advanced filter set at all → renders the Month calendar, not an empty
+    'no results' list — this is what lets the search bar's own onclear behavior be pure
+    server logic instead of a client-side branch."""
+    pytest.importorskip("fastapi", reason="web.main needs fastapi (absent in the minimal CI test env)")
+    import main
+    pdb = _setup(tmp_path, monkeypatch)
+    monkeypatch.setattr(main.db_reader, "DB_PATH", str(tmp_path / "t.db"))
+    monkeypatch.setattr(main.db_reader, "get_language", lambda: "en")
+    _seed(pdb, 1, "2026-07-04T10:00:00+00:00", kwh=10)
+
+    resp = asyncio.run(main.charges_search(_Req(), year=2026, month=7))
+    body = resp.body.decode()
+    assert 'id="charges-calendar-month"' in body          # the calendar's own root, not a list
+    assert "charge-card" not in body                       # no cards pre-rendered into the grid
+
+
+def test_charges_search_with_text_returns_flat_results(tmp_path, monkeypatch):
+    pytest.importorskip("fastapi", reason="web.main needs fastapi (absent in the minimal CI test env)")
+    import main
+    pdb = _setup(tmp_path, monkeypatch)
+    monkeypatch.setattr(main.db_reader, "DB_PATH", str(tmp_path / "t.db"))
+    monkeypatch.setattr(main.db_reader, "get_language", lambda: "en")
+    _seed(pdb, 1, "2026-07-04T10:00:00+00:00", name="Ionity Binasco")
+
+    resp = asyncio.run(main.charges_search(_Req(), q="ionity"))
+    body = resp.body.decode()
+    assert 'data-charge-id="1"' in body
+    assert 'id="charges-calendar-month"' not in body        # a flat list, not the calendar shell

--- a/tests/test_trips_calendar_search.py
+++ b/tests/test_trips_calendar_search.py
@@ -1,0 +1,203 @@
+"""Viaggi 'calendar' Month view + search — same lean pattern as the Ricariche calendar
+(tests/test_charges_calendar_search.py): a month grid of day totals, a day-drawer loaded
+lazily on click, and a text+advanced-filter search that falls back to the calendar when
+cleared. Also covers get_merge_candidates, the dedicated 🔗 view that replaced the old
+accordion's inline connectors (see main.py's trips_merge_candidates docstring for why).
+Runs on a tmp_path DB (poller schema), CI-safe."""
+import asyncio
+
+import pytest
+
+import db as D
+import db_reader
+
+
+def _setup(tmp_path, monkeypatch):
+    pdb = D.Database(str(tmp_path / "t.db"))
+    monkeypatch.setattr(db_reader, "DB_PATH", str(tmp_path / "t.db"))
+    return pdb
+
+
+def _seed(pdb, tid, started, *, ended=None, km=10.0, eff=18.0, regen=0.5, duration=15.0,
+          start_soc=60, end_soc=50, note=None, drive_mode=None, merged_into=None):
+    pdb._conn.execute(
+        "INSERT INTO trips (id, vehicle_id, started_at, ended_at, distance_km, start_soc, end_soc,"
+        " efficiency_kwh_100km, regen_kwh, duration_min, note, drive_mode, merged_into_id)"
+        " VALUES (?,1,?,?,?,?,?,?,?,?,?,?,?)",
+        (tid, started, ended or started, km, start_soc, end_soc, eff, regen, duration,
+         note, drive_mode, merged_into))
+    pdb._conn.commit()
+
+
+# ── get_trips_calendar_month: per-day totals ──────────────────────────────────
+
+def test_calendar_month_day_totals(tmp_path, monkeypatch):
+    pdb = _setup(tmp_path, monkeypatch)
+    _seed(pdb, 1, "2026-07-04T10:00:00+00:00", km=10, eff=15)
+    _seed(pdb, 2, "2026-07-04T14:00:00+00:00", km=20, eff=20)
+    _seed(pdb, 3, "2026-07-10T10:00:00+00:00", km=5)
+    _seed(pdb, 4, "2026-08-01T10:00:00+00:00", km=99)   # different month, excluded
+
+    cal = db_reader.get_trips_calendar_month(2026, 7)
+    assert cal["days"][4]["count"] == 2
+    assert cal["days"][4]["km"] == 30.0
+    # weighted avg: (10*15 + 20*20) / 30 = 18.33, rounded to 1 decimal
+    assert cal["days"][4]["avg_eff"] == 18.3
+    assert cal["total"]["count"] == 3
+    assert cal["total"]["km"] == 35.0
+
+
+def test_calendar_month_empty(tmp_path, monkeypatch):
+    _setup(tmp_path, monkeypatch)
+    cal = db_reader.get_trips_calendar_month(2026, 7)
+    assert cal["days"] == {}
+    assert cal["total"]["count"] == 0
+
+
+# ── get_trips_calendar_day ─────────────────────────────────────────────────────
+
+def test_calendar_day_trips_most_recent_first(tmp_path, monkeypatch):
+    pdb = _setup(tmp_path, monkeypatch)
+    _seed(pdb, 1, "2026-07-04T10:00:00+00:00", note="first")
+    _seed(pdb, 2, "2026-07-04T18:00:00+00:00", note="second")
+    _seed(pdb, 3, "2026-07-10T10:00:00+00:00", note="other day")
+    trips = db_reader.get_trips_calendar_day(2026, 7, 4)
+    assert [t["note"] for t in trips] == ["second", "first"]
+
+
+def test_calendar_day_no_trips_is_empty(tmp_path, monkeypatch):
+    _setup(tmp_path, monkeypatch)
+    assert db_reader.get_trips_calendar_day(2026, 7, 4) == []
+
+
+# ── search_trips: text + advanced filters ─────────────────────────────────────
+
+def test_search_text_matches_note(tmp_path, monkeypatch):
+    pdb = _setup(tmp_path, monkeypatch)
+    _seed(pdb, 1, "2026-07-04T10:00:00+00:00", note="traffico in autostrada")
+    _seed(pdb, 2, "2026-07-05T10:00:00+00:00", note="strada libera")
+    res = db_reader.search_trips(text="autostrada")
+    assert [t["id"] for t in res] == [1]
+
+
+def test_search_by_drive_mode(tmp_path, monkeypatch):
+    pdb = _setup(tmp_path, monkeypatch)
+    _seed(pdb, 1, "2026-07-04T10:00:00+00:00", drive_mode="comfort")
+    _seed(pdb, 2, "2026-07-05T10:00:00+00:00", drive_mode="sport")
+    assert [t["id"] for t in db_reader.search_trips(drive_mode="sport")] == [2]
+
+
+def test_search_km_range(tmp_path, monkeypatch):
+    pdb = _setup(tmp_path, monkeypatch)
+    _seed(pdb, 1, "2026-07-04T10:00:00+00:00", km=5)
+    _seed(pdb, 2, "2026-07-05T10:00:00+00:00", km=50)
+    assert [t["id"] for t in db_reader.search_trips(km_min=20)] == [2]
+    assert [t["id"] for t in db_reader.search_trips(km_max=20)] == [1]
+
+
+def test_search_duration_range(tmp_path, monkeypatch):
+    pdb = _setup(tmp_path, monkeypatch)
+    _seed(pdb, 1, "2026-07-04T10:00:00+00:00", duration=5)
+    _seed(pdb, 2, "2026-07-05T10:00:00+00:00", duration=60)
+    assert [t["id"] for t in db_reader.search_trips(duration_min=30)] == [2]
+    assert [t["id"] for t in db_reader.search_trips(duration_max=30)] == [1]
+
+
+def test_search_date_range_is_inclusive_local_dates(tmp_path, monkeypatch):
+    pdb = _setup(tmp_path, monkeypatch)
+    _seed(pdb, 1, "2026-07-04T10:00:00+00:00")
+    _seed(pdb, 2, "2026-07-10T10:00:00+00:00")
+    _seed(pdb, 3, "2026-07-20T10:00:00+00:00")
+    res = db_reader.search_trips(date_from="2026-07-04", date_to="2026-07-10")
+    assert {t["id"] for t in res} == {1, 2}
+
+
+def test_search_no_filters_returns_full_history_most_recent_first(tmp_path, monkeypatch):
+    pdb = _setup(tmp_path, monkeypatch)
+    _seed(pdb, 1, "2026-07-04T10:00:00+00:00")
+    _seed(pdb, 2, "2026-07-05T10:00:00+00:00")
+    assert [t["id"] for t in db_reader.search_trips()] == [2, 1]
+
+
+# ── get_trip_years / get_trip_local_date ──────────────────────────────────────
+
+def test_trip_years_distinct_descending(tmp_path, monkeypatch):
+    pdb = _setup(tmp_path, monkeypatch)
+    _seed(pdb, 1, "2024-03-01T10:00:00+00:00")
+    _seed(pdb, 2, "2026-07-04T10:00:00+00:00")
+    _seed(pdb, 3, "2026-07-05T10:00:00+00:00")
+    assert db_reader.get_trip_years() == [2026, 2024]
+
+
+def test_trip_local_date_resolves_and_missing_is_none(tmp_path, monkeypatch):
+    pdb = _setup(tmp_path, monkeypatch)
+    _seed(pdb, 1, "2026-07-04T10:00:00+00:00")
+    d = db_reader.get_trip_local_date(1)
+    assert (d.year, d.month, d.day) == (2026, 7, 4)
+    assert db_reader.get_trip_local_date(999) is None
+
+
+# ── get_merge_candidates: the 🔗 dedicated view ────────────────────────────────
+
+def test_merge_candidates_hydrates_pairs_with_full_trip_data(tmp_path, monkeypatch):
+    """A short stop between two trips (no SoC rise → no charge in the gap) is a real
+    candidate — both trips come back fully hydrated (note, km, etc.), not just bare ids,
+    since the dedicated view (unlike the old inline connectors) has no accordion row to
+    pull the rest of the data from."""
+    pdb = _setup(tmp_path, monkeypatch)
+    _seed(pdb, 1, "2026-07-04T10:00:00+00:00", ended="2026-07-04T10:20:00+00:00",
+          end_soc=55, note="leg one")
+    _seed(pdb, 2, "2026-07-04T10:23:00+00:00", start_soc=55, note="leg two")   # 3 min gap, no charge
+    candidates = db_reader.get_merge_candidates(gap_min=5)
+    assert len(candidates) == 1
+    pair = candidates[0]
+    assert pair["a"]["id"] == 1 and pair["a"]["note"] == "leg one"
+    assert pair["b"]["id"] == 2 and pair["b"]["note"] == "leg two"
+    assert pair["gap_min"] == 3
+
+
+def test_merge_candidates_excludes_pair_with_charge_in_gap(tmp_path, monkeypatch):
+    pdb = _setup(tmp_path, monkeypatch)
+    _seed(pdb, 1, "2026-07-04T10:00:00+00:00", ended="2026-07-04T10:20:00+00:00", end_soc=40)
+    _seed(pdb, 2, "2026-07-04T10:23:00+00:00", start_soc=80)   # SoC rose → charged in the gap
+    assert db_reader.get_merge_candidates(gap_min=5) == []
+
+
+def test_merge_candidates_none_when_no_pairs(tmp_path, monkeypatch):
+    _setup(tmp_path, monkeypatch)
+    assert db_reader.get_merge_candidates() == []
+
+
+# ── main.py wiring: the empty-search fallback ─────────────────────────────────
+
+class _Req:
+    """Minimal Starlette Request stand-in — these endpoints only read query params
+    (already bound by FastAPI) and pass `request` straight to TemplateResponse."""
+
+
+def test_trips_search_falls_back_to_calendar_when_all_filters_empty(tmp_path, monkeypatch):
+    pytest.importorskip("fastapi", reason="web.main needs fastapi (absent in the minimal CI test env)")
+    import main
+    pdb = _setup(tmp_path, monkeypatch)
+    monkeypatch.setattr(main.db_reader, "DB_PATH", str(tmp_path / "t.db"))
+    monkeypatch.setattr(main.db_reader, "get_language", lambda: "en")
+    _seed(pdb, 1, "2026-07-04T10:00:00+00:00")
+
+    resp = asyncio.run(main.trips_search(_Req(), year=2026, month=7))
+    body = resp.body.decode()
+    assert 'id="trips-calendar-month"' in body
+    assert 'class="trip-row"' not in body
+
+
+def test_trips_search_with_text_returns_flat_results(tmp_path, monkeypatch):
+    pytest.importorskip("fastapi", reason="web.main needs fastapi (absent in the minimal CI test env)")
+    import main
+    pdb = _setup(tmp_path, monkeypatch)
+    monkeypatch.setattr(main.db_reader, "DB_PATH", str(tmp_path / "t.db"))
+    monkeypatch.setattr(main.db_reader, "get_language", lambda: "en")
+    _seed(pdb, 1, "2026-07-04T10:00:00+00:00", note="mountain pass")
+
+    resp = asyncio.run(main.trips_search(_Req(), q="mountain"))
+    body = resp.body.decode()
+    assert 'data-trip-id="1"' in body
+    assert 'id="trips-calendar-month"' not in body

--- a/tests/test_trips_calendar_search.py
+++ b/tests/test_trips_calendar_search.py
@@ -201,3 +201,25 @@ def test_trips_search_with_text_returns_flat_results(tmp_path, monkeypatch):
     body = resp.body.decode()
     assert 'data-trip-id="1"' in body
     assert 'id="trips-calendar-month"' not in body
+
+
+def test_trips_search_empty_numeric_fields_dont_422(tmp_path, monkeypatch):
+    """#175: an unfilled advanced-filter number input still submits its name with an EMPTY
+    value (km_min=""), which a bare `float | None` FastAPI param 422s trying to parse —
+    htmx then silently does nothing. Only `drive_mode` set, every numeric field an empty
+    string exactly as the real browser form submits them."""
+    pytest.importorskip("fastapi", reason="web.main needs fastapi (absent in the minimal CI test env)")
+    import main
+    pdb = _setup(tmp_path, monkeypatch)
+    monkeypatch.setattr(main.db_reader, "DB_PATH", str(tmp_path / "t.db"))
+    monkeypatch.setattr(main.db_reader, "get_language", lambda: "en")
+    _seed(pdb, 1, "2026-07-04T10:00:00+00:00", drive_mode="sport")
+    _seed(pdb, 2, "2026-07-05T10:00:00+00:00", drive_mode="comfort")
+
+    resp = asyncio.run(main.trips_search(
+        _Req(), drive_mode="sport", km_min="", km_max="", eff_min="", eff_max="",
+        duration_min="", duration_max="", date_from="", date_to=""))
+    assert resp.status_code == 200
+    body = resp.body.decode()
+    assert 'data-trip-id="1"' in body
+    assert 'data-trip-id="2"' not in body

--- a/tests/test_wallbox_calendar.py
+++ b/tests/test_wallbox_calendar.py
@@ -1,0 +1,114 @@
+"""Wallbox 'calendar' Month view — same lean pattern as Ricariche/Viaggi: a month grid of
+day totals computed from the ALREADY-STORED charge columns (ac_energy_kwh/energy_added_kwh),
+not the per-session Home Assistant history fetch (_session_energy) the old accordion ran for
+every session up front. That stays lazy, computed only for the one day a user opens.
+Runs on a tmp_path DB (poller schema), CI-safe — no real Home Assistant involved."""
+import db as D
+import db_reader
+
+
+def _setup(tmp_path, monkeypatch):
+    pdb = D.Database(str(tmp_path / "t.db"))
+    monkeypatch.setattr(db_reader, "DB_PATH", str(tmp_path / "t.db"))
+    return pdb
+
+
+def _seed_home_charge(pdb, cid, started, *, ended=None, ac=10.0, dc=9.0):
+    """A HOME charge WITH a power curve (a charging=1 position inside its window) — the
+    same "still has raw data" gate charges_with_power/_wallbox_home_charges_raw use."""
+    ended = ended or started
+    pdb._conn.execute(
+        "INSERT INTO charges (id, vehicle_id, started_at, ended_at, start_soc, end_soc,"
+        " energy_added_kwh, ac_energy_kwh, location_type)"
+        " VALUES (?,1,?,?,40,60,?,?,'HOME')",
+        (cid, started, ended, dc, ac))
+    pdb._conn.execute(
+        "INSERT INTO positions (vehicle_id, recorded_at, charging) VALUES (1,?,1)",
+        (started,))
+    pdb._conn.commit()
+
+
+# ── get_wallbox_calendar_month: per-day AC/DC totals ──────────────────────────
+
+def test_calendar_month_day_totals(tmp_path, monkeypatch):
+    pdb = _setup(tmp_path, monkeypatch)
+    _seed_home_charge(pdb, 1, "2026-07-04T10:00:00+00:00", ac=10, dc=9)
+    _seed_home_charge(pdb, 2, "2026-07-04T20:00:00+00:00", ac=20, dc=18)
+    _seed_home_charge(pdb, 3, "2026-07-10T10:00:00+00:00", ac=5, dc=4.5)
+    _seed_home_charge(pdb, 4, "2026-08-01T10:00:00+00:00", ac=99, dc=90)  # different month
+
+    cal = db_reader.get_wallbox_calendar_month(2026, 7)
+    assert cal["days"][4]["count"] == 2
+    assert cal["days"][4]["ac"] == 30.0
+    assert cal["days"][4]["dc"] == 27.0
+    assert cal["days"][4]["eff"] == 90.0
+    assert cal["total"]["count"] == 3
+    assert cal["total"]["ac"] == 35.0
+
+
+def test_calendar_month_empty(tmp_path, monkeypatch):
+    _setup(tmp_path, monkeypatch)
+    cal = db_reader.get_wallbox_calendar_month(2026, 7)
+    assert cal["days"] == {}
+    assert cal["total"]["count"] == 0
+    assert cal["total"]["eff"] is None
+
+
+def test_calendar_month_excludes_charges_without_a_power_curve(tmp_path, monkeypatch):
+    """A HOME charge with no charging=1 position (data pruned, or never captured) has
+    nothing to expand into a comparison chart, so it must not inflate the day total —
+    same gate charges_with_power already applies for the old accordion."""
+    pdb = _setup(tmp_path, monkeypatch)
+    pdb._conn.execute(
+        "INSERT INTO charges (id, vehicle_id, started_at, ended_at, start_soc, end_soc,"
+        " energy_added_kwh, ac_energy_kwh, location_type)"
+        " VALUES (1,1,'2026-07-04T10:00:00+00:00','2026-07-04T10:00:00+00:00',40,60,9,10,'HOME')")
+    pdb._conn.commit()
+    cal = db_reader.get_wallbox_calendar_month(2026, 7)
+    assert cal["days"] == {}
+
+
+def test_calendar_month_excludes_non_home_charges(tmp_path, monkeypatch):
+    pdb = _setup(tmp_path, monkeypatch)
+    pdb._conn.execute(
+        "INSERT INTO charges (id, vehicle_id, started_at, ended_at, start_soc, end_soc,"
+        " energy_added_kwh, location_type) "
+        "VALUES (1,1,'2026-07-04T10:00:00+00:00','2026-07-04T10:00:00+00:00',40,60,20,'HPC')")
+    pdb._conn.execute(
+        "INSERT INTO positions (vehicle_id, recorded_at, charging) VALUES (1,'2026-07-04T10:00:00+00:00',1)")
+    pdb._conn.commit()
+    cal = db_reader.get_wallbox_calendar_month(2026, 7)
+    assert cal["days"] == {}
+
+
+# ── get_wallbox_calendar_day ───────────────────────────────────────────────────
+
+def test_calendar_day_sessions_most_recent_first(tmp_path, monkeypatch):
+    pdb = _setup(tmp_path, monkeypatch)
+    _seed_home_charge(pdb, 1, "2026-07-04T10:00:00+00:00")
+    _seed_home_charge(pdb, 2, "2026-07-04T20:00:00+00:00")
+    _seed_home_charge(pdb, 3, "2026-07-10T10:00:00+00:00")   # different day
+    sessions = db_reader.get_wallbox_calendar_day(2026, 7, 4)
+    assert [s["id"] for s in sessions] == [2, 1]        # most recent (20:00 UTC) first
+    assert sessions[0]["time"].count(":") == 1          # "HH:MM", local-tz (host-dependent, not asserted exactly)
+    assert set(sessions[0].keys()) == {"id", "time"}    # no ac/dc/eff yet — main.py adds those lazily
+
+
+def test_calendar_day_no_sessions_is_empty(tmp_path, monkeypatch):
+    _setup(tmp_path, monkeypatch)
+    assert db_reader.get_wallbox_calendar_day(2026, 7, 4) == []
+
+
+# ── get_wallbox_years ──────────────────────────────────────────────────────────
+
+def test_wallbox_years_distinct_descending(tmp_path, monkeypatch):
+    pdb = _setup(tmp_path, monkeypatch)
+    _seed_home_charge(pdb, 1, "2024-03-01T10:00:00+00:00")
+    _seed_home_charge(pdb, 2, "2026-07-04T10:00:00+00:00")
+    _seed_home_charge(pdb, 3, "2026-07-05T10:00:00+00:00")
+    assert db_reader.get_wallbox_years() == [2026, 2024]
+
+
+def test_wallbox_years_empty_when_no_sessions(tmp_path, monkeypatch):
+    _setup(tmp_path, monkeypatch)
+    assert db_reader.get_wallbox_years() == []

--- a/web/db_reader.py
+++ b/web/db_reader.py
@@ -3,7 +3,7 @@ import json
 import math
 import sqlite3
 import time
-from datetime import datetime, timezone, timedelta
+from datetime import date, datetime, timezone, timedelta
 from pathlib import Path
 from typing import Optional
 import os
@@ -128,6 +128,23 @@ def _local_iso(s):
     template slices like started_at[11:16] display local time. Falls back to input."""
     dt = _local_dt(s)
     return dt.isoformat() if dt else s
+
+
+def today_local() -> date:
+    """Today's calendar date in the user's configured timezone — the Charges calendar's
+    default Month view opens here."""
+    return datetime.now(_local_tz()).date()
+
+
+def get_charge_local_date(charge_id: int) -> "date | None":
+    """The local calendar date a charge falls on, or None if it doesn't exist — used to
+    open the Charges calendar on the right month when following a ?highlight=<id> link
+    (e.g. from a map popup) that may point at a charge outside the current month."""
+    row = _get().execute("SELECT started_at FROM charges WHERE id=?", (charge_id,)).fetchone()
+    if not row or not row["started_at"]:
+        return None
+    dt = _local_dt(row["started_at"])
+    return dt.date() if dt else None
 
 # In-memory optimistic overlay: after a command, keep the expected state for
 # _OPT_TTL seconds so the poller can't overwrite it before the UI refreshes.
@@ -2277,6 +2294,26 @@ def get_mergeable_pairs(gap_min: int = TRIP_MERGE_GAP_DEFAULT) -> list:
     return pairs
 
 
+def get_merge_candidates(gap_min: int = TRIP_MERGE_GAP_DEFAULT) -> list[dict]:
+    """Mergeable pairs (get_mergeable_pairs) hydrated with full trip_row.html-ready data —
+    the Viaggi 🔗 button's dedicated candidates view. Previously these surfaced as inline
+    connectors between adjacent rows in the full year/month/day accordion; the calendar
+    only ever renders one day at a time, so there's no "whole page" left to scan for
+    them — this view lists just the (typically few) actual candidates instead, unrelated
+    to whichever month is currently browsed. Most-recent-first."""
+    pairs = get_mergeable_pairs(gap_min)
+    if not pairs:
+        return []
+    trips_by_id = {t["id"]: t for t in _localized_trips(get_trips(limit=1_000_000))}
+    out = []
+    for p in pairs:
+        a, b = trips_by_id.get(p["a_id"]), trips_by_id.get(p["b_id"])
+        if a and b:
+            out.append({"a": a, "b": b, "gap_min": p["gap_min"]})
+    out.sort(key=lambda p: p["b"]["started_at"], reverse=True)
+    return out
+
+
 def merge_trips(parent_id: int, child_id: int, gap_min: int = TRIP_MERGE_GAP_DEFAULT) -> dict:
     """Merge child into parent (the earlier of the two becomes the parent). Re-validates the
     eligibility server-side. Reversible: only sets merged_into_id, nothing is overwritten."""
@@ -2433,6 +2470,180 @@ def reev_fuel_summary() -> Optional[dict]:
         "engine_km": round(engine_km, 1),
         "avg_l_100km": round(engine_l / engine_km * 100, 1) if engine_km > 0.5 else None,
     }
+
+
+def _trip_blended_rate_fn():
+    """Blended €/kWh-over-time lookup, built once from ALL priced charges (same basis as
+    get_trip_detail's own per-trip rate) — shared by the Trips calendar and search so every
+    view prices a trip identically."""
+    cost_bp: dict = {}
+    seen_ch: dict = {}
+    for c in _get().execute(
+            "SELECT vehicle_id, ended_at, start_soc, end_soc, cost, ac_energy_kwh, location_type, "
+            "energy_added_kwh FROM charges WHERE vehicle_id = COALESCE(?, vehicle_id) "
+            "AND ended_at IS NOT NULL AND cost IS NOT NULL "
+            "AND energy_added_kwh > 0 ORDER BY vehicle_id, ended_at", (_current_vehicle_id(),)).fetchall():
+        seen_ch.setdefault(c["vehicle_id"], []).append(dict(c))
+        cost_bp.setdefault(c["vehicle_id"], []).append(
+            (c["ended_at"], _wac_blend(seen_ch[c["vehicle_id"]])))
+
+    def _rate_at(vehicle_id, ts_utc):
+        rate = None
+        for ended_at, wac in cost_bp.get(vehicle_id, ()):   # ascending → last ≤ ts wins
+            if ended_at <= ts_utc:
+                rate = wac
+            else:
+                break
+        return rate
+    return _rate_at
+
+
+def _localized_trips(trips: list[dict]) -> list[dict]:
+    """Per-trip localization + derived cost shared by the Trips calendar and search: the
+    ec_pending flag, local start/end times, and cost (efficiency × distance × the blended
+    €/kWh in effect AT the trip's time — same basis as get_trip_detail). Adds a private
+    `_dt` (aware, local-tz datetime) for the caller's OWN day/date bucketing or filtering."""
+    rate_at = _trip_blended_rate_fn()
+    ec_on = get_setting("ec_trip_energy_enabled", "1") == "1"
+    ec_cutoff = get_setting("ec_trip_since", "")
+    now_ts = datetime.now(timezone.utc).timestamp()
+    out = []
+    for t in trips:
+        if not t.get("started_at"):
+            continue
+        dt = _local_dt(t["started_at"])
+        if dt is None:
+            continue
+        raw_start = t["started_at"]
+        ee = _trip_epoch(t.get("ended_at")) if t.get("ended_at") else None
+        t["ec_pending"] = bool(
+            ec_on and not t.get("ec_stable") and ec_cutoff
+            and t["started_at"] >= ec_cutoff
+            and ee and (now_ts - ee) < 6 * 3600)
+        t["started_at"] = dt.isoformat()
+        t["ended_at"] = _local_iso(t.get("ended_at"))
+        km = t.get("distance_km") or 0
+        eff = t.get("efficiency_kwh_100km")
+        energy = (eff * km / 100) if (eff and km) else 0
+        rate = rate_at(t.get("vehicle_id"), raw_start) if energy else None
+        t["cost"] = (energy * rate) if (energy and rate) else 0
+        t["_dt"] = dt
+        out.append(t)
+    return out
+
+
+def get_trips_calendar_month(year: int, month: int) -> dict:
+    """Per-day totals for the Viaggi calendar's Month view: session count, distance, regen
+    and derived cost for each day of `year`/`month` (local time), plus the month's own
+    total. Mirrors get_charges_calendar_month; the day's actual trips are fetched lazily
+    (see get_trips_calendar_day) only when a cell is clicked."""
+    trips = _localized_trips(get_trips(limit=1_000_000))
+    days: dict[int, dict] = {}
+    total = {"count": 0, "km": 0.0, "regen": 0.0, "cost": 0.0, "_eff_wsum": 0.0, "_eff_wdist": 0.0}
+    for t in trips:
+        dt = t["_dt"]
+        if dt.year != year or dt.month != month:
+            continue
+        d = days.setdefault(dt.day, {"count": 0, "km": 0.0, "regen": 0.0, "cost": 0.0,
+                                      "_eff_wsum": 0.0, "_eff_wdist": 0.0})
+        km = t.get("distance_km") or 0
+        eff = t.get("efficiency_kwh_100km")
+        regen = t.get("regen_kwh") or 0
+        cost = t.get("cost") or 0
+        for node in (d, total):
+            node["count"] += 1
+            node["km"] = round(node["km"] + km, 2)
+            node["regen"] = round(node["regen"] + regen, 3)
+            node["cost"] = round(node["cost"] + cost, 2)
+            if eff and km > 0:
+                node["_eff_wsum"] += km * eff
+                node["_eff_wdist"] += km
+    for node in list(days.values()) + [total]:
+        node["avg_eff"] = round(node["_eff_wsum"] / node["_eff_wdist"], 1) if node["_eff_wdist"] > 0 else None
+        del node["_eff_wsum"]
+        del node["_eff_wdist"]
+    return {"year": year, "month": month, "days": days, "total": total}
+
+
+def get_trips_calendar_day(year: int, month: int, day: int) -> list[dict]:
+    """The trip_row.html-ready trips for ONE calendar day — backs the Month view's day
+    drawer, most-recent-first."""
+    trips = _localized_trips(get_trips(limit=1_000_000))
+    trips = [t for t in trips if t["_dt"].year == year and t["_dt"].month == month and t["_dt"].day == day]
+    trips.sort(key=lambda t: t["started_at"], reverse=True)
+    return trips
+
+
+def search_trips(text: str = "", date_from: str = "", date_to: str = "",
+                  km_min: "float | None" = None, km_max: "float | None" = None,
+                  eff_min: "float | None" = None, eff_max: "float | None" = None,
+                  duration_min: "float | None" = None, duration_max: "float | None" = None,
+                  drive_mode: str = "") -> list[dict]:
+    """Flat, most-recent-first list of trips matching ALL given filters — the Viaggi search
+    bar. `text` matches the user note (substring, case-insensitive); `drive_mode` is
+    comfort/normal/sport (#107); the km/efficiency/duration filters are inclusive ranges;
+    `date_from`/`date_to` are inclusive "YYYY-MM-DD" LOCAL calendar dates."""
+    trips = _localized_trips(get_trips(limit=1_000_000))
+    q = (text or "").strip().lower()
+    dm = (drive_mode or "").strip().lower()
+    try:
+        d_from = date.fromisoformat(date_from) if date_from else None
+    except ValueError:
+        d_from = None
+    try:
+        d_to = date.fromisoformat(date_to) if date_to else None
+    except ValueError:
+        d_to = None
+    out = []
+    for t in trips:
+        if q and q not in (t.get("note") or "").lower():
+            continue
+        if dm and (t.get("drive_mode") or "").lower() != dm:
+            continue
+        km = t.get("distance_km") or 0
+        if km_min is not None and km < km_min:
+            continue
+        if km_max is not None and km > km_max:
+            continue
+        eff = t.get("efficiency_kwh_100km")
+        if eff_min is not None and (eff is None or eff < eff_min):
+            continue
+        if eff_max is not None and (eff is None or eff > eff_max):
+            continue
+        dur = t.get("duration_min") or 0
+        if duration_min is not None and dur < duration_min:
+            continue
+        if duration_max is not None and dur > duration_max:
+            continue
+        day_ = t["_dt"].date()
+        if d_from and day_ < d_from:
+            continue
+        if d_to and day_ > d_to:
+            continue
+        out.append(t)
+    out.sort(key=lambda t: t["started_at"], reverse=True)
+    return out
+
+
+def get_trip_years() -> list[int]:
+    """Distinct years (local time, most recent first) with at least one trip — populates
+    the Viaggi calendar's year-jump pills with only years the user actually has data for."""
+    years = set()
+    for t in get_trips(limit=1_000_000):
+        dt = _local_dt(t.get("started_at"))
+        if dt:
+            years.add(dt.year)
+    return sorted(years, reverse=True)
+
+
+def get_trip_local_date(trip_id: int) -> "date | None":
+    """The local calendar date a trip falls on, or None if it doesn't exist — used to open
+    the Viaggi calendar on the right month when following a ?highlight=<id> link."""
+    row = _get().execute("SELECT started_at FROM trips WHERE id=?", (trip_id,)).fetchone()
+    if not row or not row["started_at"]:
+        return None
+    dt = _local_dt(row["started_at"])
+    return dt.date() if dt else None
 
 
 def get_trips_grouped() -> list[dict]:
@@ -3011,6 +3222,69 @@ def charges_with_power(limit: int = 30) -> list[dict]:
     return [dict(r) for r in rows]
 
 
+def _wallbox_home_charges_raw() -> list[dict]:
+    """All-time HOME charges that still have a power curve (same EXISTS gate as
+    charges_with_power, but selecting BOTH energy columns and unbounded — the Wallbox
+    calendar's month totals and year-jump need the full history, not just the newest 30)."""
+    db = _get()
+    rows = db.execute(
+        "SELECT c.id, c.started_at, c.energy_added_kwh, c.ac_energy_kwh FROM charges c "
+        "WHERE c.vehicle_id = COALESCE(?, c.vehicle_id) AND c.location_type = 'HOME' AND EXISTS ("
+        "  SELECT 1 FROM positions p WHERE p.vehicle_id = c.vehicle_id AND p.charging = 1"
+        "  AND p.recorded_at >= c.started_at"
+        "  AND (c.ended_at IS NULL OR p.recorded_at <= c.ended_at)"
+        ") ORDER BY c.started_at DESC",
+        (_current_vehicle_id(),)).fetchall()
+    return [dict(r) for r in rows]
+
+
+def get_wallbox_calendar_month(year: int, month: int) -> dict:
+    """Per-day AC(wallbox)/DC(battery) totals for the Wallbox calendar's Month view — uses
+    the ALREADY-STORED charge columns (ac_energy_kwh/energy_added_kwh), not the per-session
+    HA-history integration main.py's _session_energy does. That stays lazy, computed only
+    for the one day the user opens (see get_wallbox_calendar_day) instead of for every
+    session up front — each call is a live Home Assistant history fetch."""
+    charges = _wallbox_home_charges_raw()
+    days: dict[int, dict] = {}
+    total = {"count": 0, "ac": 0.0, "dc": 0.0}
+    for c in charges:
+        dt = _local_dt(c["started_at"])
+        if dt is None or dt.year != year or dt.month != month:
+            continue
+        d = days.setdefault(dt.day, {"count": 0, "ac": 0.0, "dc": 0.0})
+        ac = c.get("ac_energy_kwh") or 0
+        dc = c.get("energy_added_kwh") or 0
+        for node in (d, total):
+            node["count"] += 1
+            node["ac"] = round(node["ac"] + ac, 2)
+            node["dc"] = round(node["dc"] + dc, 2)
+    for node in list(days.values()) + [total]:
+        node["eff"] = round(100 * node["dc"] / node["ac"], 1) if node["ac"] else None
+    return {"year": year, "month": month, "days": days, "total": total}
+
+
+def get_wallbox_calendar_day(year: int, month: int, day: int) -> list[dict]:
+    """{id, time} for each HOME-with-power charge on ONE calendar day, most-recent-first —
+    the day-drawer computes each session's precise AC/DC comparison (_session_energy,
+    main.py) lazily per row, not all up front like the old accordion did."""
+    out = []
+    for c in _wallbox_home_charges_raw():
+        dt = _local_dt(c["started_at"])
+        if dt and dt.year == year and dt.month == month and dt.day == day:
+            out.append({"id": c["id"], "time": dt.strftime("%H:%M"), "_sort": c["started_at"]})
+    out.sort(key=lambda s: s["_sort"], reverse=True)
+    for s in out:
+        del s["_sort"]
+    return out
+
+
+def get_wallbox_years() -> list[int]:
+    """Distinct years (local time, most recent first) with at least one HOME charge that
+    has a power curve — populates the Wallbox calendar's year-jump pills."""
+    years = {dt.year for dt in (_local_dt(c["started_at"]) for c in _wallbox_home_charges_raw()) if dt}
+    return sorted(years, reverse=True)
+
+
 def is_home_charge(charge_id: int) -> bool:
     """True only when the charge is tagged HOME (= the wallbox)."""
     db = _get()
@@ -3237,6 +3511,28 @@ def _billed_kwh(c) -> float:
     return c.get("energy_added_kwh") or 0
 
 
+def _filter_by_station(charges: list[dict], station: str) -> list[dict]:
+    """Narrow a charge list to the one physical station a "lat,lon" key (3-decimal rounded,
+    from get_charging_stations()) identifies. Shared by the accordion, the calendar and
+    search — a malformed key yields [], never a crash or the unfiltered set."""
+    try:
+        lat_r, lon_r = (round(float(v), 3) for v in station.split(","))
+    except (ValueError, AttributeError):
+        return []
+    return [c for c in charges if c.get("latitude") is not None and c.get("longitude") is not None
+            and round(c["latitude"], 3) == lat_r and round(c["longitude"], 3) == lon_r]
+
+
+def get_charge_years(station: str | None = None) -> list[int]:
+    """Distinct years (local time, most recent first) with at least one charge — populates
+    the Ricariche calendar's year-jump pills with only years the user actually has data for."""
+    charges = get_charges(limit=1_000_000)
+    if station:
+        charges = _filter_by_station(charges, station)
+    years = {dt.year for dt in (_local_dt(c.get("started_at")) for c in charges) if dt}
+    return sorted(years, reverse=True)
+
+
 def get_charges_grouped(station: str | None = None) -> list[dict]:
     """Return charges nested as year → month → day. `station`, when given, is a
     "lat,lon" key from get_charging_stations() (same rounding) — narrows the tree to
@@ -3247,13 +3543,7 @@ def get_charges_grouped(station: str | None = None) -> list[dict]:
     # loading everything is fine — same unbounded read the CSV export and monthly report use.
     charges = get_charges(limit=1_000_000)
     if station:
-        try:
-            lat_r, lon_r = (round(float(v), 3) for v in station.split(","))
-        except (ValueError, AttributeError):
-            charges = []
-        else:
-            charges = [c for c in charges if c.get("latitude") is not None and c.get("longitude") is not None
-                       and round(c["latitude"], 3) == lat_r and round(c["longitude"], 3) == lon_r]
+        charges = _filter_by_station(charges, station)
     from collections import OrderedDict
     db = _get()
 
@@ -3297,6 +3587,119 @@ def get_charges_grouped(station: str | None = None) -> list[dict]:
                 node["has_cost"] = True
 
     return list(years.values())
+
+
+def _localized_charges(charges: list[dict]) -> list[dict]:
+    """Per-charge localization shared by the Charges calendar and search: local start/end
+    times + the real-charging-window display, same convention get_charges_grouped applies
+    inline — so charge_card.html renders identically wherever it's included. Adds a private
+    `_dt` (aware, local-tz datetime) for the caller's OWN day/date bucketing or filtering;
+    never rendered, so its presence in the dict is harmless to charge_card.html."""
+    db = _get()
+    out = []
+    for c in charges:
+        if not c.get("started_at"):
+            continue
+        dt = _local_dt(c["started_at"])
+        if dt is None:
+            continue
+        c["active_window"] = _charge_window_display(db, c.get("started_at"), c.get("ended_at"))
+        c["started_at"] = dt.isoformat()
+        c["ended_at"] = _local_iso(c.get("ended_at"))
+        c["_dt"] = dt
+        out.append(c)
+    return out
+
+
+def get_charges_calendar_month(year: int, month: int, station: str | None = None) -> dict:
+    """Per-day totals for the Ricariche calendar's Month view: how many sessions, kWh and
+    cost landed on each day of `year`/`month` (local time, same billed-kWh convention as
+    get_charges_grouped) plus the month's own total — the grid only needs counts, the
+    day's actual charges are fetched lazily (see get_charges_calendar_day) when a cell is
+    clicked, so a month never ships more than ~31 small numbers to the template."""
+    charges = _localized_charges(get_charges(limit=1_000_000))
+    if station:
+        charges = _filter_by_station(charges, station)
+    days: dict[int, dict] = {}
+    total = {"count": 0, "kwh": 0.0, "cost": 0.0, "has_cost": False}
+    for c in charges:
+        dt = c["_dt"]
+        if dt.year != year or dt.month != month:
+            continue
+        d = days.setdefault(dt.day, {"count": 0, "kwh": 0.0, "cost": 0.0, "has_cost": False})
+        kwh = _billed_kwh(c)
+        for node in (d, total):
+            node["kwh"] = round(node["kwh"] + kwh, 2)
+            node["count"] += 1
+            if c.get("cost") is not None:
+                node["cost"] = round(node["cost"] + (c["cost"] or 0), 2)
+                node["has_cost"] = True
+    return {"year": year, "month": month, "days": days, "total": total}
+
+
+def get_charges_calendar_day(year: int, month: int, day: int, station: str | None = None) -> list[dict]:
+    """The charge_card.html-ready charges for ONE calendar day — backs the Month view's
+    day drawer, most-recent-first."""
+    charges = _localized_charges(get_charges(limit=1_000_000))
+    if station:
+        charges = _filter_by_station(charges, station)
+    charges = [c for c in charges
+               if c["_dt"].year == year and c["_dt"].month == month and c["_dt"].day == day]
+    charges.sort(key=lambda c: c["started_at"], reverse=True)
+    return charges
+
+
+def search_charges(text: str = "", charge_type: str = "",
+                    cost_min: float | None = None, cost_max: float | None = None,
+                    kwh_min: float | None = None, kwh_max: float | None = None,
+                    date_from: str = "", date_to: str = "",
+                    station: str | None = None) -> list[dict]:
+    """Flat, most-recent-first list of charges matching ALL given filters — the Ricariche
+    search bar. `text` matches the station name OR the user note (substring, case-
+    insensitive); `charge_type` is a location_type key (AC/FAST/HPC/HOME/FREE/MANUAL);
+    the kWh/cost filters compare against the SAME billed figure the card shows
+    (_billed_kwh); `date_from`/`date_to` are inclusive "YYYY-MM-DD" LOCAL calendar dates.
+    Loads the full history like get_charges_grouped (#67 — no default limit may hide
+    older charges) and filters in Python — same convention as the calendar/accordion,
+    no SQL date-math needed since _local_dt already localizes the timezone."""
+    charges = _localized_charges(get_charges(limit=1_000_000))
+    if station:
+        charges = _filter_by_station(charges, station)
+    q = (text or "").strip().lower()
+    ctype = (charge_type or "").strip().upper()
+    try:
+        d_from = date.fromisoformat(date_from) if date_from else None
+    except ValueError:
+        d_from = None
+    try:
+        d_to = date.fromisoformat(date_to) if date_to else None
+    except ValueError:
+        d_to = None
+    out = []
+    for c in charges:
+        if q and q not in (c.get("location_name") or "").lower() \
+             and q not in (c.get("note") or "").lower():
+            continue
+        if ctype and (c.get("location_type") or "") != ctype:
+            continue
+        kwh = _billed_kwh(c)
+        if kwh_min is not None and kwh < kwh_min:
+            continue
+        if kwh_max is not None and kwh > kwh_max:
+            continue
+        cost = c.get("cost")
+        if cost_min is not None and (cost is None or cost < cost_min):
+            continue
+        if cost_max is not None and (cost is None or cost > cost_max):
+            continue
+        day = c["_dt"].date()
+        if d_from and day < d_from:
+            continue
+        if d_to and day > d_to:
+            continue
+        out.append(c)
+    out.sort(key=lambda c: c["started_at"], reverse=True)
+    return out
 
 
 def get_stats_summary() -> dict:

--- a/web/i18n.py
+++ b/web/i18n.py
@@ -21,6 +21,7 @@ _LOCALES_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "locales
 # ── Load every locale once at import time ────────────────────────────────────
 _T: dict[str, dict[str, str]] = {}
 _MONTHS: dict[str, dict[str, list]] = {}
+_WEEKDAYS: dict[str, list] = {}
 
 for _fname in sorted(os.listdir(_LOCALES_DIR)):
     if not _fname.endswith(".json"):
@@ -31,6 +32,8 @@ for _fname in sorted(os.listdir(_LOCALES_DIR)):
     _T[_lang] = _data.get("translations", {})
     if "months" in _data:
         _MONTHS[_lang] = _data["months"]
+    if "weekdays" in _data:
+        _WEEKDAYS[_lang] = _data["weekdays"]["abbr"]
 
 
 # ── Public API (identical behaviour to the old monolithic version) ───────────
@@ -44,6 +47,13 @@ def fmt_day_month_year(lang: str, dt) -> str:
     """Localized "%d %b %Y" → e.g. "02 giu 2026". Used for day labels in history trees."""
     months = _MONTHS.get(lang, _MONTHS["en"])
     return f"{dt.day:02d} {months['abbr'][dt.month - 1]} {dt.year}"
+
+
+def weekday_abbrs(lang: str) -> list:
+    """Monday-first 3-ish-letter weekday abbreviations for the Charges calendar's column
+    header (e.g. ["Lun", "Mar", ...]) — a fixed 7-item list, unrelated to locale.strftime
+    week-start conventions."""
+    return _WEEKDAYS.get(lang, _WEEKDAYS["en"])
 
 
 def get_t(lang: str):

--- a/web/locales/de.json
+++ b/web/locales/de.json
@@ -306,6 +306,7 @@
     "wb_th_dc": "Batterie DC",
     "wb_th_eff": "Wirkungsgrad",
     "wallbox_compare_legend": "Gelieferte kWh vs. in die Batterie (pro Sitzung, zusammengefasst nach Tag/Monat/Jahr)",
+    "wallbox_calendar_pick_day": "Wähle einen Tag mit Ladevorgängen für die Details",
     "wb_tot_ac": "kWh Wallbox",
     "wb_tot_dc": "kWh Batterie",
     "wb_tot_eff": "Wirkungsgrad",
@@ -529,6 +530,21 @@
     "speed_profile": "Geschwindigkeitsprofil",
     "not_enough_gps": "Nicht genug GPS-Punkte",
     "charges_title": "Ladungen",
+    "charges_calendar_prev": "Vorheriger Monat",
+    "charges_calendar_next": "Nächster Monat",
+    "charges_calendar_today": "Zu heute springen",
+    "charges_calendar_pick_day": "Wähle einen Tag mit Ladevorgängen für die Details",
+    "charges_search_placeholder": "Ladestation oder Notiz suchen...",
+    "charges_search_advanced": "Erweiterte Filter",
+    "charges_search_all_types": "Alle Typen",
+    "charges_search_date_from": "Von",
+    "charges_search_date_to": "Bis",
+    "charges_search_kwh_min": "kWh min",
+    "charges_search_kwh_max": "kWh max",
+    "charges_search_cost_min": "Kosten min",
+    "charges_search_cost_max": "Kosten max",
+    "charges_search_results": "Ergebnisse",
+    "charges_search_no_results": "Keine Ladung entspricht der Suche",
     "ac_dc_distribution": "AC-/DC-Verteilung",
     "ac_charge": "AC",
     "dc_charge": "DC",
@@ -618,6 +634,14 @@
     "merge_existing": "Zusammengeführte Fahrten",
     "merge_segments": "Segmente",
     "unmerge_btn": "Trennen",
+    "unmerge_confirm": "Diese zusammengeführte Fahrt wieder in ihre ursprünglichen Abschnitte trennen?",
+    "trips_calendar_pick_day": "Wähle einen Tag mit Fahrten für die Details",
+    "trips_search_placeholder": "Fahrtnotizen durchsuchen...",
+    "trips_search_all_modes": "Alle Modi",
+    "trips_search_km_min": "Distanz min",
+    "trips_search_km_max": "Distanz max",
+    "trips_search_duration_min": "Dauer min (Min.)",
+    "trips_search_no_results": "Keine Fahrt entspricht der Suche",
     "merge_preview_title": "Vorschau zusammengeführte Fahrt",
     "driving_only": "nur Fahrt",
     "merge_stop": "Halt",
@@ -935,5 +959,8 @@
       "Nov",
       "Dez"
     ]
+  },
+  "weekdays": {
+    "abbr": ["Mo", "Di", "Mi", "Do", "Fr", "Sa", "So"]
   }
 }

--- a/web/locales/de.json
+++ b/web/locales/de.json
@@ -544,6 +544,7 @@
     "charges_search_cost_min": "Kosten min",
     "charges_search_cost_max": "Kosten max",
     "charges_search_results": "Ergebnisse",
+    "charges_search_clear": "Zurück zum Kalender",
     "charges_search_no_results": "Keine Ladung entspricht der Suche",
     "ac_dc_distribution": "AC-/DC-Verteilung",
     "ac_charge": "AC",

--- a/web/locales/en.json
+++ b/web/locales/en.json
@@ -600,6 +600,7 @@
     "charges_search_cost_min": "Cost min",
     "charges_search_cost_max": "Cost max",
     "charges_search_results": "results",
+    "charges_search_clear": "Back to calendar",
     "charges_search_no_results": "No charge matches your search",
     "ac_dc_distribution": "AC vs DC Distribution",
     "ac_charge": "AC",

--- a/web/locales/en.json
+++ b/web/locales/en.json
@@ -360,6 +360,7 @@
     "wb_th_dc": "Battery DC",
     "wb_th_eff": "Efficiency",
     "wallbox_compare_legend": "kWh delivered vs into the battery (per session, rolled up by day/month/year)",
+    "wallbox_calendar_pick_day": "Pick a day with charges to see its detail",
     "wb_tot_ac": "Wallbox kWh",
     "wb_tot_dc": "Battery kWh",
     "wb_tot_eff": "Efficiency",
@@ -585,6 +586,21 @@
     "charges_title": "Charges",
     "charges_station_filter": "Showing charges at",
     "charges_station_clear": "Clear filter",
+    "charges_calendar_prev": "Previous month",
+    "charges_calendar_next": "Next month",
+    "charges_calendar_today": "Jump to today",
+    "charges_calendar_pick_day": "Pick a day with charges to see its detail",
+    "charges_search_placeholder": "Search station or note...",
+    "charges_search_advanced": "Advanced filters",
+    "charges_search_all_types": "All types",
+    "charges_search_date_from": "From",
+    "charges_search_date_to": "To",
+    "charges_search_kwh_min": "kWh min",
+    "charges_search_kwh_max": "kWh max",
+    "charges_search_cost_min": "Cost min",
+    "charges_search_cost_max": "Cost max",
+    "charges_search_results": "results",
+    "charges_search_no_results": "No charge matches your search",
     "ac_dc_distribution": "AC vs DC Distribution",
     "ac_charge": "AC",
     "dc_charge": "DC",
@@ -674,6 +690,14 @@
     "merge_existing": "Merged trips",
     "merge_segments": "segments",
     "unmerge_btn": "Unmerge",
+    "unmerge_confirm": "Split this merged trip back into its original segments?",
+    "trips_calendar_pick_day": "Pick a day with trips to see its detail",
+    "trips_search_placeholder": "Search trip notes...",
+    "trips_search_all_modes": "All modes",
+    "trips_search_km_min": "Min distance",
+    "trips_search_km_max": "Max distance",
+    "trips_search_duration_min": "Min duration (min)",
+    "trips_search_no_results": "No trip matches your search",
     "merge_preview_title": "Merged trip preview",
     "driving_only": "driving only",
     "merge_stop": "stop",
@@ -1015,5 +1039,8 @@
       "Nov",
       "Dec"
     ]
+  },
+  "weekdays": {
+    "abbr": ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
   }
 }

--- a/web/locales/fr.json
+++ b/web/locales/fr.json
@@ -360,6 +360,7 @@
     "wb_th_dc": "Batterie DC",
     "wb_th_eff": "Rendement",
     "wallbox_compare_legend": "kWh fournis vs entrés dans la batterie (par session, cumulés par jour/mois/année)",
+    "wallbox_calendar_pick_day": "Choisissez un jour avec des recharges pour voir le détail",
     "wb_tot_ac": "kWh Wallbox",
     "wb_tot_dc": "kWh Batterie",
     "wb_tot_eff": "Rendement",
@@ -585,6 +586,21 @@
     "charges_title": "Recharges",
     "charges_station_filter": "Recharges à",
     "charges_station_clear": "Effacer le filtre",
+    "charges_calendar_prev": "Mois précédent",
+    "charges_calendar_next": "Mois suivant",
+    "charges_calendar_today": "Revenir à aujourd'hui",
+    "charges_calendar_pick_day": "Choisissez un jour avec des recharges pour voir le détail",
+    "charges_search_placeholder": "Rechercher une borne ou une note...",
+    "charges_search_advanced": "Filtres avancés",
+    "charges_search_all_types": "Tous les types",
+    "charges_search_date_from": "Du",
+    "charges_search_date_to": "Au",
+    "charges_search_kwh_min": "kWh min",
+    "charges_search_kwh_max": "kWh max",
+    "charges_search_cost_min": "Coût min",
+    "charges_search_cost_max": "Coût max",
+    "charges_search_results": "résultats",
+    "charges_search_no_results": "Aucune recharge ne correspond à la recherche",
     "ac_dc_distribution": "Répartition AC / DC",
     "ac_charge": "AC",
     "dc_charge": "DC",
@@ -674,6 +690,14 @@
     "merge_existing": "Trajets fusionnés",
     "merge_segments": "segments",
     "unmerge_btn": "Séparer",
+    "unmerge_confirm": "Séparer ce trajet fusionné en ses segments d'origine ?",
+    "trips_calendar_pick_day": "Choisissez un jour avec des trajets pour voir le détail",
+    "trips_search_placeholder": "Rechercher dans les notes de trajet...",
+    "trips_search_all_modes": "Tous les modes",
+    "trips_search_km_min": "Distance min",
+    "trips_search_km_max": "Distance max",
+    "trips_search_duration_min": "Durée min (min)",
+    "trips_search_no_results": "Aucun trajet ne correspond à la recherche",
     "merge_preview_title": "Aperçu du trajet fusionné",
     "driving_only": "conduite seule",
     "merge_stop": "arrêt",
@@ -1015,5 +1039,8 @@
       "nov",
       "déc"
     ]
+  },
+  "weekdays": {
+    "abbr": ["Lun", "Mar", "Mer", "Jeu", "Ven", "Sam", "Dim"]
   }
 }

--- a/web/locales/fr.json
+++ b/web/locales/fr.json
@@ -600,6 +600,7 @@
     "charges_search_cost_min": "Coût min",
     "charges_search_cost_max": "Coût max",
     "charges_search_results": "résultats",
+    "charges_search_clear": "Retour au calendrier",
     "charges_search_no_results": "Aucune recharge ne correspond à la recherche",
     "ac_dc_distribution": "Répartition AC / DC",
     "ac_charge": "AC",

--- a/web/locales/it.json
+++ b/web/locales/it.json
@@ -360,6 +360,7 @@
     "wb_th_dc": "Batteria DC",
     "wb_th_eff": "Rendimento",
     "wallbox_compare_legend": "kWh erogati vs entrati in batteria (per sessione, aggregati per giorno/mese/anno)",
+    "wallbox_calendar_pick_day": "Seleziona un giorno con ricariche per vederne il dettaglio",
     "wb_tot_ac": "kWh Wallbox",
     "wb_tot_dc": "kWh Batteria",
     "wb_tot_eff": "Efficienza",
@@ -585,6 +586,21 @@
     "charges_title": "Ricariche",
     "charges_station_filter": "Ricariche presso",
     "charges_station_clear": "Rimuovi filtro",
+    "charges_calendar_prev": "Mese precedente",
+    "charges_calendar_next": "Mese successivo",
+    "charges_calendar_today": "Torna a oggi",
+    "charges_calendar_pick_day": "Seleziona un giorno con ricariche per vederne il dettaglio",
+    "charges_search_placeholder": "Cerca colonnina o nota...",
+    "charges_search_advanced": "Filtri avanzati",
+    "charges_search_all_types": "Tutti i tipi",
+    "charges_search_date_from": "Dal",
+    "charges_search_date_to": "Al",
+    "charges_search_kwh_min": "kWh min",
+    "charges_search_kwh_max": "kWh max",
+    "charges_search_cost_min": "Costo min",
+    "charges_search_cost_max": "Costo max",
+    "charges_search_results": "risultati",
+    "charges_search_no_results": "Nessuna ricarica corrisponde alla ricerca",
     "ac_dc_distribution": "Distribuzione AC vs DC",
     "ac_charge": "AC",
     "dc_charge": "DC",
@@ -674,6 +690,14 @@
     "merge_existing": "Viaggi uniti",
     "merge_segments": "segmenti",
     "unmerge_btn": "Separa",
+    "unmerge_confirm": "Separare questo viaggio unito nei segmenti originali?",
+    "trips_calendar_pick_day": "Seleziona un giorno con viaggi per vederne il dettaglio",
+    "trips_search_placeholder": "Cerca nelle note dei viaggi...",
+    "trips_search_all_modes": "Tutte le modalità",
+    "trips_search_km_min": "Distanza min",
+    "trips_search_km_max": "Distanza max",
+    "trips_search_duration_min": "Durata min (min)",
+    "trips_search_no_results": "Nessun viaggio corrisponde alla ricerca",
     "merge_preview_title": "Anteprima viaggio unito",
     "driving_only": "solo guida",
     "merge_stop": "sosta",
@@ -1015,5 +1039,8 @@
       "nov",
       "dic"
     ]
+  },
+  "weekdays": {
+    "abbr": ["Lun", "Mar", "Mer", "Gio", "Ven", "Sab", "Dom"]
   }
 }

--- a/web/locales/it.json
+++ b/web/locales/it.json
@@ -600,6 +600,7 @@
     "charges_search_cost_min": "Costo min",
     "charges_search_cost_max": "Costo max",
     "charges_search_results": "risultati",
+    "charges_search_clear": "Torna al calendario",
     "charges_search_no_results": "Nessuna ricarica corrisponde alla ricerca",
     "ac_dc_distribution": "Distribuzione AC vs DC",
     "ac_charge": "AC",

--- a/web/locales/pl.json
+++ b/web/locales/pl.json
@@ -295,6 +295,7 @@
     "wb_th_dc": "Bateria DC",
     "wb_th_eff": "Sprawność",
     "wallbox_compare_legend": "kWh dostarczone vs do baterii (na sesję, zbiorczo wg dnia/miesiąca/roku)",
+    "wallbox_calendar_pick_day": "Wybierz dzień z ładowaniami, aby zobaczyć szczegóły",
     "wb_tot_ac": "kWh Wallbox",
     "wb_tot_dc": "kWh Bateria",
     "wb_tot_eff": "Sprawność",
@@ -518,6 +519,21 @@
     "speed_profile": "Profil prędkości",
     "not_enough_gps": "Za mało punktów GPS",
     "charges_title": "Ładowania",
+    "charges_calendar_prev": "Poprzedni miesiąc",
+    "charges_calendar_next": "Następny miesiąc",
+    "charges_calendar_today": "Wróć do dziś",
+    "charges_calendar_pick_day": "Wybierz dzień z ładowaniami, aby zobaczyć szczegóły",
+    "charges_search_placeholder": "Szukaj stacji lub notatki...",
+    "charges_search_advanced": "Filtry zaawansowane",
+    "charges_search_all_types": "Wszystkie typy",
+    "charges_search_date_from": "Od",
+    "charges_search_date_to": "Do",
+    "charges_search_kwh_min": "kWh min",
+    "charges_search_kwh_max": "kWh maks",
+    "charges_search_cost_min": "Koszt min",
+    "charges_search_cost_max": "Koszt maks",
+    "charges_search_results": "wyników",
+    "charges_search_no_results": "Żadne ładowanie nie pasuje do wyszukiwania",
     "ac_dc_distribution": "Rozkład AC vs DC",
     "ac_charge": "AC",
     "dc_charge": "DC",
@@ -607,6 +623,14 @@
     "merge_existing": "Połączone trasy",
     "merge_segments": "segmenty",
     "unmerge_btn": "Rozłącz",
+    "unmerge_confirm": "Rozdzielić tę połączoną trasę z powrotem na oryginalne odcinki?",
+    "trips_calendar_pick_day": "Wybierz dzień z trasami, aby zobaczyć szczegóły",
+    "trips_search_placeholder": "Szukaj w notatkach tras...",
+    "trips_search_all_modes": "Wszystkie tryby",
+    "trips_search_km_min": "Dystans min",
+    "trips_search_km_max": "Dystans maks",
+    "trips_search_duration_min": "Czas min (min)",
+    "trips_search_no_results": "Żadna trasa nie pasuje do wyszukiwania",
     "merge_preview_title": "Podgląd połączonej trasy",
     "driving_only": "tylko jazda",
     "merge_stop": "postój",
@@ -924,5 +948,8 @@
       "lis",
       "gru"
     ]
+  },
+  "weekdays": {
+    "abbr": ["Pon", "Wt", "Śr", "Czw", "Pt", "Sob", "Nie"]
   }
 }

--- a/web/locales/pl.json
+++ b/web/locales/pl.json
@@ -533,6 +533,7 @@
     "charges_search_cost_min": "Koszt min",
     "charges_search_cost_max": "Koszt maks",
     "charges_search_results": "wyników",
+    "charges_search_clear": "Wróć do kalendarza",
     "charges_search_no_results": "Żadne ładowanie nie pasuje do wyszukiwania",
     "ac_dc_distribution": "Rozkład AC vs DC",
     "ac_charge": "AC",

--- a/web/locales/pt-PT.json
+++ b/web/locales/pt-PT.json
@@ -600,6 +600,7 @@
     "charges_search_cost_min": "Custo mín",
     "charges_search_cost_max": "Custo máx",
     "charges_search_results": "resultados",
+    "charges_search_clear": "Voltar ao calendário",
     "charges_search_no_results": "Nenhum carregamento corresponde à pesquisa",
     "ac_dc_distribution": "Distribuição AC vs DC",
     "ac_charge": "AC",

--- a/web/locales/pt-PT.json
+++ b/web/locales/pt-PT.json
@@ -360,6 +360,7 @@
     "wb_th_dc": "Bateria DC",
     "wb_th_eff": "Eficiência",
     "wallbox_compare_legend": "kWh entregues vs kWh na bateria (por sessão, agregado por dia/mês/ano)",
+    "wallbox_calendar_pick_day": "Escolhe um dia com carregamentos para ver o detalhe",
     "wb_tot_ac": "kWh wallbox",
     "wb_tot_dc": "kWh bateria",
     "wb_tot_eff": "Eficiência",
@@ -585,6 +586,21 @@
     "charges_title": "Carregamentos",
     "charges_station_filter": "A mostrar carregamentos em",
     "charges_station_clear": "Limpar filtro",
+    "charges_calendar_prev": "Mês anterior",
+    "charges_calendar_next": "Mês seguinte",
+    "charges_calendar_today": "Ir para hoje",
+    "charges_calendar_pick_day": "Escolhe um dia com carregamentos para ver o detalhe",
+    "charges_search_placeholder": "Pesquisar estação ou nota...",
+    "charges_search_advanced": "Filtros avançados",
+    "charges_search_all_types": "Todos os tipos",
+    "charges_search_date_from": "De",
+    "charges_search_date_to": "Até",
+    "charges_search_kwh_min": "kWh mín",
+    "charges_search_kwh_max": "kWh máx",
+    "charges_search_cost_min": "Custo mín",
+    "charges_search_cost_max": "Custo máx",
+    "charges_search_results": "resultados",
+    "charges_search_no_results": "Nenhum carregamento corresponde à pesquisa",
     "ac_dc_distribution": "Distribuição AC vs DC",
     "ac_charge": "AC",
     "dc_charge": "DC",
@@ -674,6 +690,14 @@
     "merge_existing": "Viagens unidas",
     "merge_segments": "segmentos",
     "unmerge_btn": "Separar",
+    "unmerge_confirm": "Separar esta viagem unida nos segmentos originais?",
+    "trips_calendar_pick_day": "Escolhe um dia com viagens para ver o detalhe",
+    "trips_search_placeholder": "Pesquisar nas notas das viagens...",
+    "trips_search_all_modes": "Todos os modos",
+    "trips_search_km_min": "Distância mín",
+    "trips_search_km_max": "Distância máx",
+    "trips_search_duration_min": "Duração mín (min)",
+    "trips_search_no_results": "Nenhuma viagem corresponde à pesquisa",
     "merge_preview_title": "Pré-visualização da viagem unida",
     "driving_only": "apenas condução",
     "merge_stop": "paragem",
@@ -1015,5 +1039,8 @@
       "nov",
       "dez"
     ]
+  },
+  "weekdays": {
+    "abbr": ["Seg", "Ter", "Qua", "Qui", "Sex", "Sáb", "Dom"]
   }
 }

--- a/web/main.py
+++ b/web/main.py
@@ -488,10 +488,11 @@ async def trips_search(request: Request, q: str = "", drive_mode: str = "",
         km_min=units.dist_to_km(km_min), km_max=units.dist_to_km(km_max),
         eff_min=eff_min, eff_max=eff_max, duration_min=duration_min, duration_max=duration_max,
         date_from=date_from, date_to=date_to)
+    today = db_reader.today_local()
     return templates.TemplateResponse(request, "partials/trips_search_results.html", {
         "t": i18n.get_t(lang), "fmt_dur": _fmt_dur,
         "is_reev": db_reader.get_setting("is_reev", "0") == "1", "research": research.research_enabled(),
-        "trips": trips,
+        "trips": trips, "year": year or today.year, "month": month or today.month,
     })
 
 
@@ -802,9 +803,11 @@ async def charges_search(request: Request, q: str = "", type: str = "",
         text=q, charge_type=type, cost_min=cost_min, cost_max=cost_max,
         kwh_min=kwh_min, kwh_max=kwh_max, date_from=date_from, date_to=date_to,
         station=station or None)
+    today = db_reader.today_local()
     return templates.TemplateResponse(request, "partials/charges_search_results.html", {
         "t": i18n.get_t(lang), "charge_types": db_reader.CHARGE_TYPES, "fmt_dur": _fmt_dur,
-        "charges": charges,
+        "charges": charges, "station": station,
+        "year": year or today.year, "month": month or today.month,
     })
 
 

--- a/web/main.py
+++ b/web/main.py
@@ -133,11 +133,20 @@ import units
 for _name in ("dist", "speed", "temp", "pressure", "elev"):
     templates.env.filters[_name] = getattr(units, _name)
 templates.env.filters["eff"] = units.efficiency
+def _eff_cls(e) -> str:
+    """Efficiency → pill colour class — shared by trip_row.html wherever a trip is rendered
+    (day-drawer, search results, merge candidates), not just the old trips.html-local macro."""
+    if e is None:
+        return ""
+    return "eff-good" if e < 18 else "eff-mid" if e < 22 else "eff-bad"
+
+
 templates.env.globals.update(
     dist_unit=units.dist_unit, speed_unit=units.speed_unit, temp_unit=units.temp_unit,
     pressure_unit=units.pressure_unit, eff_unit=units.eff_unit, elev_unit=units.elev_unit,
     dist_val=units.dist_val, speed_val=units.speed_val, temp_val=units.temp_val,
     eff_val=units.eff_val, elev_val=units.elev_val, unit_system=units.get_unit_system,
+    eff_cls=_eff_cls,
 )
 app.mount("/static", StaticFiles(directory=str(Path(__file__).parent / "static")), name="static")
 
@@ -383,20 +392,122 @@ async def overview(request: Request):
 @app.get("/trips", response_class=HTMLResponse)
 async def trips_page(request: Request, highlight: int = 0):
     vehicle, _ = db_reader.get_vehicle()
-    grouped = db_reader.get_trips_grouped()
-    total   = sum(y["count"] for y in grouped)
     summary = db_reader.get_trips_summary()
-    # All eligible adjacent pairs at the WIDEST gap → drawn as connectors in the tree and filtered
-    # live (client-side) by the gap slider. Keyed by the later trip's id (b_id = the row above a in
-    # the newest-first list); value carries the earlier trip a_id + the actual stop gap in minutes.
-    merge_pairs = {p["b_id"]: {"a_id": p["a_id"], "gap": p["gap_min"]}
-                   for p in db_reader.get_mergeable_pairs(db_reader.TRIP_MERGE_GAP_MAX)}
+    total   = summary.get("count") or 0
+    # The calendar's Month view opens on today — or, following a ?highlight=<id> link, on
+    # whichever month that ONE trip actually falls on (same convention as Ricariche).
+    today = db_reader.today_local()
+    cal_year, cal_month, cal_open_day = today.year, today.month, 0
+    if highlight:
+        hl_date = db_reader.get_trip_local_date(highlight)
+        if hl_date:
+            cal_year, cal_month, cal_open_day = hl_date.year, hl_date.month, hl_date.day
     return templates.TemplateResponse(request, "trips.html", _ctx(
-        page="trips", vehicle=vehicle, grouped=grouped,
+        page="trips", vehicle=vehicle,
         total=total, highlight=highlight, summary=summary,
-        merge_pairs=merge_pairs, merge_gap_default=db_reader.TRIP_MERGE_GAP_DEFAULT,
+        merge_gap_default=db_reader.TRIP_MERGE_GAP_DEFAULT,
         merge_gap_min=db_reader.TRIP_MERGE_GAP_MIN, merge_gap_max=db_reader.TRIP_MERGE_GAP_MAX,
+        cal_year=cal_year, cal_month=cal_month, cal_open_day=cal_open_day,
+        cal_years=db_reader.get_trip_years(),
     ))
+
+
+def _render_trips_calendar(request: Request, year: int, month: int, open_day: int = 0):
+    """Shared by /api/trips/calendar and the search endpoint's empty-filters fallback."""
+    import calendar as calmod
+    from datetime import date
+    today = db_reader.today_local()
+    year, month = year or today.year, month or today.month
+    month = max(1, min(12, month))
+    cal = db_reader.get_trips_calendar_month(year, month)
+    weeks = []
+    for week in calmod.Calendar(firstweekday=0).monthdayscalendar(year, month):
+        row = []
+        for day in week:
+            row.append(None if day == 0 else {
+                "day": day, **cal["days"].get(day, {"count": 0, "km": 0.0, "regen": 0.0,
+                                                      "cost": 0.0, "avg_eff": None})})
+        weeks.append(row)
+    prev_year, prev_month = (year - 1, 12) if month == 1 else (year, month - 1)
+    next_year, next_month = (year + 1, 1) if month == 12 else (year, month + 1)
+    lang = db_reader.get_language()
+    ctx = {
+        "t": i18n.get_t(lang), "year": year, "month": month, "weeks": weeks, "total": cal["total"],
+        "month_label": i18n.fmt_month_year(lang, date(year, month, 1)),
+        "weekday_abbrs": i18n.weekday_abbrs(lang),
+        "prev_year": prev_year, "prev_month": prev_month,
+        "next_year": next_year, "next_month": next_month,
+        "today": today, "fmt_dur": _fmt_dur,
+        "is_reev": db_reader.get_setting("is_reev", "0") == "1", "research": research.research_enabled(),
+    }
+    if open_day and open_day in cal["days"]:
+        ctx["open_day_trips"] = db_reader.get_trips_calendar_day(year, month, open_day)
+        ctx["open_day_label"] = i18n.fmt_day_month_year(lang, date(year, month, open_day))
+    return templates.TemplateResponse(request, "partials/trips_calendar_month.html", ctx)
+
+
+@app.get("/api/trips/calendar", response_class=HTMLResponse)
+async def trips_calendar(request: Request, year: int = 0, month: int = 0, open_day: int = 0):
+    """Viaggi 'calendar' Month view (HTMX partial, day totals only) — the day drawer loads
+    a day's actual trips lazily on click (see trips_calendar_day below)."""
+    return _render_trips_calendar(request, year, month, open_day)
+
+
+@app.get("/api/trips/calendar/day", response_class=HTMLResponse)
+async def trips_calendar_day(request: Request, year: int, month: int, day: int):
+    """One day's trips for the Month view's day drawer."""
+    lang = db_reader.get_language()
+    from datetime import date
+    return templates.TemplateResponse(request, "partials/trips_calendar_day.html", {
+        "t": i18n.get_t(lang), "fmt_dur": _fmt_dur,
+        "is_reev": db_reader.get_setting("is_reev", "0") == "1", "research": research.research_enabled(),
+        "trips": db_reader.get_trips_calendar_day(year, month, day),
+        "day_label": i18n.fmt_day_month_year(lang, date(year, month, day)),
+    })
+
+
+@app.get("/api/trips/search", response_class=HTMLResponse)
+async def trips_search(request: Request, q: str = "", drive_mode: str = "",
+                        km_min: "float | None" = None, km_max: "float | None" = None,
+                        eff_min: "float | None" = None, eff_max: "float | None" = None,
+                        duration_min: "float | None" = None, duration_max: "float | None" = None,
+                        date_from: str = "", date_to: str = "",
+                        year: int = 0, month: int = 0):
+    """Viaggi free-text + advanced-filter search (HTMX partial) — replaces the calendar with
+    a flat, most-recent-first list of matches. No filter at all (search cleared) falls back
+    to the calendar Month view instead of an empty list. km_min/km_max are typed in the
+    user's own distance unit (the form label follows dist_unit()) and converted to km here,
+    same as a manually-entered odometer reading — search_trips itself is always metric."""
+    if not any((q.strip(), drive_mode.strip(), km_min is not None, km_max is not None,
+                eff_min is not None, eff_max is not None, duration_min is not None,
+                duration_max is not None, date_from.strip(), date_to.strip())):
+        return _render_trips_calendar(request, year, month)
+    lang = db_reader.get_language()
+    trips = db_reader.search_trips(
+        text=q, drive_mode=drive_mode,
+        km_min=units.dist_to_km(km_min), km_max=units.dist_to_km(km_max),
+        eff_min=eff_min, eff_max=eff_max, duration_min=duration_min, duration_max=duration_max,
+        date_from=date_from, date_to=date_to)
+    return templates.TemplateResponse(request, "partials/trips_search_results.html", {
+        "t": i18n.get_t(lang), "fmt_dur": _fmt_dur,
+        "is_reev": db_reader.get_setting("is_reev", "0") == "1", "research": research.research_enabled(),
+        "trips": trips,
+    })
+
+
+@app.get("/api/trips/merge-candidates", response_class=HTMLResponse)
+async def trips_merge_candidates(request: Request, gap: int = db_reader.TRIP_MERGE_GAP_DEFAULT):
+    """Viaggi 🔗 button (HTMX partial) — replaces the calendar with the (typically few) actual
+    mergeable pairs across all history, independent of whichever month is currently browsed."""
+    gap = max(db_reader.TRIP_MERGE_GAP_MIN, min(db_reader.TRIP_MERGE_GAP_MAX, gap))
+    lang = db_reader.get_language()
+    return templates.TemplateResponse(request, "partials/trip_merge_candidates.html", {
+        "t": i18n.get_t(lang), "fmt_dur": _fmt_dur,
+        "is_reev": db_reader.get_setting("is_reev", "0") == "1", "research": research.research_enabled(),
+        "candidates": db_reader.get_merge_candidates(gap), "gap": gap,
+        "merge_gap_default": db_reader.TRIP_MERGE_GAP_DEFAULT,
+        "merge_gap_min": db_reader.TRIP_MERGE_GAP_MIN, "merge_gap_max": db_reader.TRIP_MERGE_GAP_MAX,
+    })
 
 
 def _route_svg(points: list[dict], w: int = 84, h: int = 48, pad: int = 6) -> str:
@@ -591,25 +702,110 @@ async def set_charge_note(request: Request, charge_id: int):
 @app.get("/charges", response_class=HTMLResponse)
 async def charges_page(request: Request, highlight: int = 0, station: str = ""):
     vehicle, _ = db_reader.get_vehicle()
-    grouped = db_reader.get_charges_grouped(station=station or None)
     stats   = db_reader.get_charge_stats()
     prices  = db_reader.get_charge_prices()
     status  = db_reader.get_latest_status()
-    total   = sum(y["count"] for y in grouped)
+    total   = stats.get("session_count") or 0
     station_info = None
     if station:
         # Uncapped: a station reached via ?station=<key> must resolve regardless of the map's
-        # top_n cap, same as get_charges_grouped(station=...) below.
+        # top_n cap, same as search_charges(station=...) below.
         stations = db_reader.get_charging_stations(top_n=None)
         station_info = next((s for s in stations if s["key"] == station), None)
+    # The calendar's Month view opens on today — or, following a ?highlight=<id> link (e.g. a
+    # map popup), on whichever month that ONE charge actually falls on, so it isn't invisible.
+    today = db_reader.today_local()
+    cal_year, cal_month, cal_open_day = today.year, today.month, 0
+    if highlight:
+        hl_date = db_reader.get_charge_local_date(highlight)
+        if hl_date:
+            cal_year, cal_month, cal_open_day = hl_date.year, hl_date.month, hl_date.day
     return templates.TemplateResponse(request, "charges.html", _ctx(
-        page="charges", vehicle=vehicle, grouped=grouped,
+        page="charges", vehicle=vehicle,
         stats=stats, total=total, highlight=highlight,
         charge_types=db_reader.CHARGE_TYPES, prices=prices,
         status=status, ac_dc=db_reader.get_ac_dc_stats(),
         unconfirmed=db_reader.unconfirmed_charges_count(),
         station=station, station_info=station_info,
+        cal_year=cal_year, cal_month=cal_month, cal_open_day=cal_open_day,
+        cal_years=db_reader.get_charge_years(station or None),
     ))
+
+
+def _render_charges_calendar(request: Request, year: int, month: int, station: str, open_day: int = 0):
+    """Shared by /api/charges/calendar and the search endpoint's empty-filters fallback."""
+    import calendar as calmod
+    from datetime import date
+    today = db_reader.today_local()
+    year, month = year or today.year, month or today.month
+    month = max(1, min(12, month))
+    cal = db_reader.get_charges_calendar_month(year, month, station=station or None)
+    weeks = []
+    for week in calmod.Calendar(firstweekday=0).monthdayscalendar(year, month):
+        row = []
+        for day in week:
+            row.append(None if day == 0 else {
+                "day": day, **cal["days"].get(day, {"count": 0, "kwh": 0.0, "cost": 0.0, "has_cost": False})})
+        weeks.append(row)
+    prev_year, prev_month = (year - 1, 12) if month == 1 else (year, month - 1)
+    next_year, next_month = (year + 1, 1) if month == 12 else (year, month + 1)
+    lang = db_reader.get_language()
+    ctx = {
+        "t": i18n.get_t(lang), "year": year, "month": month, "weeks": weeks, "total": cal["total"],
+        "month_label": i18n.fmt_month_year(lang, date(year, month, 1)),
+        "weekday_abbrs": i18n.weekday_abbrs(lang),
+        "prev_year": prev_year, "prev_month": prev_month,
+        "next_year": next_year, "next_month": next_month,
+        "today": today, "station": station,
+        "charge_types": db_reader.CHARGE_TYPES, "fmt_dur": _fmt_dur,
+    }
+    if open_day and open_day in cal["days"]:
+        ctx["open_day_charges"] = db_reader.get_charges_calendar_day(year, month, open_day, station=station or None)
+        ctx["open_day_label"] = i18n.fmt_day_month_year(lang, date(year, month, open_day))
+    return templates.TemplateResponse(request, "partials/charges_calendar_month.html", ctx)
+
+
+@app.get("/api/charges/calendar", response_class=HTMLResponse)
+async def charges_calendar(request: Request, year: int = 0, month: int = 0, station: str = "", open_day: int = 0):
+    """Ricariche 'calendar' Month view (HTMX partial, day totals only) — the day drawer
+    loads a day's actual charge cards lazily on click (see charges_calendar_day below),
+    so a month never ships more markup than the handful of days the user opens."""
+    return _render_charges_calendar(request, year, month, station, open_day)
+
+
+@app.get("/api/charges/calendar/day", response_class=HTMLResponse)
+async def charges_calendar_day(request: Request, year: int, month: int, day: int, station: str = ""):
+    """One day's charge cards for the Month view's day drawer."""
+    lang = db_reader.get_language()
+    charges = db_reader.get_charges_calendar_day(year, month, day, station=station or None)
+    from datetime import date
+    return templates.TemplateResponse(request, "partials/charges_calendar_day.html", {
+        "t": i18n.get_t(lang), "charge_types": db_reader.CHARGE_TYPES, "fmt_dur": _fmt_dur,
+        "charges": charges, "day_label": i18n.fmt_day_month_year(lang, date(year, month, day)),
+    })
+
+
+@app.get("/api/charges/search", response_class=HTMLResponse)
+async def charges_search(request: Request, q: str = "", type: str = "",
+                          cost_min: "float | None" = None, cost_max: "float | None" = None,
+                          kwh_min: "float | None" = None, kwh_max: "float | None" = None,
+                          date_from: str = "", date_to: str = "", station: str = "",
+                          year: int = 0, month: int = 0):
+    """Ricariche free-text + advanced-filter search (HTMX partial) — replaces the calendar
+    with a flat, most-recent-first list of matches (see charge_card.html). No filter at all
+    (search cleared) falls back to the calendar Month view instead of an empty list."""
+    if not any((q.strip(), type.strip(), cost_min is not None, cost_max is not None,
+                kwh_min is not None, kwh_max is not None, date_from.strip(), date_to.strip())):
+        return _render_charges_calendar(request, year, month, station)
+    lang = db_reader.get_language()
+    charges = db_reader.search_charges(
+        text=q, charge_type=type, cost_min=cost_min, cost_max=cost_max,
+        kwh_min=kwh_min, kwh_max=kwh_max, date_from=date_from, date_to=date_to,
+        station=station or None)
+    return templates.TemplateResponse(request, "partials/charges_search_results.html", {
+        "t": i18n.get_t(lang), "charge_types": db_reader.CHARGE_TYPES, "fmt_dur": _fmt_dur,
+        "charges": charges,
+    })
 
 
 @app.get("/statistics", response_class=HTMLResponse)
@@ -1424,9 +1620,12 @@ async def wallbox_page(request: Request):
     if db_reader.get_setting("wallbox_enabled", "0") != "1":
         return RedirectResponse(request.headers.get("x-ingress-path", "") + "/settings")
     vehicle, _ = db_reader.get_vehicle()
+    today = db_reader.today_local()
     return templates.TemplateResponse(request, "wallbox.html", _ctx(
         page="wallbox", vehicle=vehicle,
         configured=ha_client.is_configured() and bool(ha_client.get_mapping()),
+        cal_year=today.year, cal_month=today.month,
+        cal_years=db_reader.get_wallbox_years(),
     ))
 
 
@@ -1850,6 +2049,64 @@ async def wallbox_sessions(request: Request):
     return templates.TemplateResponse(request, "partials/wallbox_sessions.html", _ctx(
         tree=_wallbox_sessions_grouped(),
     ))
+
+
+def _wallbox_day_sessions(year: int, month: int, day: int) -> list:
+    """A day's sessions with their precise AC/DC comparison (_session_energy — a live Home
+    Assistant history fetch per session) computed HERE, lazily, only for the one day being
+    opened — never for a whole month/history up front."""
+    sessions = db_reader.get_wallbox_calendar_day(year, month, day)
+    for s in sessions:
+        s.update(_session_energy(db_reader.get_charge_power_curve(s["id"])))
+    return sessions
+
+
+@app.get("/api/wallbox/calendar", response_class=HTMLResponse)
+async def wallbox_calendar(request: Request, year: int = 0, month: int = 0, open_day: int = 0):
+    """Wallbox 'calendar' Month view (HTMX partial, day totals from the ALREADY-STORED
+    charge columns) — the day drawer computes each session's precise AC/DC comparison
+    lazily on click (see wallbox_calendar_day below), so opening the page never fires a
+    Home Assistant history request per session like the old full accordion did."""
+    import calendar as calmod
+    from datetime import date
+    today = db_reader.today_local()
+    year, month = year or today.year, month or today.month
+    month = max(1, min(12, month))
+    cal = db_reader.get_wallbox_calendar_month(year, month)
+    weeks = []
+    for week in calmod.Calendar(firstweekday=0).monthdayscalendar(year, month):
+        row = []
+        for day in week:
+            row.append(None if day == 0 else {
+                "day": day, **cal["days"].get(day, {"count": 0, "ac": 0.0, "dc": 0.0, "eff": None})})
+        weeks.append(row)
+    prev_year, prev_month = (year - 1, 12) if month == 1 else (year, month - 1)
+    next_year, next_month = (year + 1, 1) if month == 12 else (year, month + 1)
+    lang = db_reader.get_language()
+    ctx = {
+        "t": i18n.get_t(lang), "year": year, "month": month, "weeks": weeks, "total": cal["total"],
+        "month_label": i18n.fmt_month_year(lang, date(year, month, 1)),
+        "weekday_abbrs": i18n.weekday_abbrs(lang),
+        "prev_year": prev_year, "prev_month": prev_month,
+        "next_year": next_year, "next_month": next_month,
+        "today": today,
+    }
+    if open_day and open_day in cal["days"]:
+        ctx["open_day_sessions"] = _wallbox_day_sessions(year, month, open_day)
+        ctx["open_day_label"] = i18n.fmt_day_month_year(lang, date(year, month, open_day))
+    return templates.TemplateResponse(request, "partials/wallbox_calendar_month.html", ctx)
+
+
+@app.get("/api/wallbox/calendar/day", response_class=HTMLResponse)
+async def wallbox_calendar_day(request: Request, year: int, month: int, day: int):
+    """One day's sessions for the Month view's day drawer."""
+    lang = db_reader.get_language()
+    from datetime import date
+    return templates.TemplateResponse(request, "partials/wallbox_calendar_day.html", {
+        "t": i18n.get_t(lang),
+        "sessions": _wallbox_day_sessions(year, month, day),
+        "day_label": i18n.fmt_day_month_year(lang, date(year, month, day)),
+    })
 
 
 @app.get("/api/wallbox/compare-chart", response_class=HTMLResponse)

--- a/web/main.py
+++ b/web/main.py
@@ -218,6 +218,23 @@ def _state_color(pos: dict) -> str:
     if pos.get("plug_connected"): return "text-teal-300"   # cable in, not actively charging
     return "text-green-400"
 
+def _opt_float(s: str) -> "float | None":
+    """An optional numeric search-filter field, as FastAPI/Pydantic won't: a query param
+    typed `float | None = None` only defaults to None when the param is ABSENT, not when
+    it's present-but-empty — and an empty number/date input still submits its name with
+    an empty VALUE (e.g. `cost_min=`), which FastAPI then 422s trying to parse "" as a
+    float. Every optional numeric search filter takes `str` and goes through this instead
+    (#175 — an empty advanced-filter field made the whole search request fail silently,
+    since htmx doesn't swap in a non-2xx response)."""
+    s = (s or "").strip()
+    if not s:
+        return None
+    try:
+        return float(s)
+    except ValueError:
+        return None
+
+
 def _fmt_dur(minutes) -> str:
     """Readable duration: '10h 19m' from an hour up, '45 min' below, '—' when missing —
     so a long charge reads as hours, not a bare '619 min'."""
@@ -468,25 +485,30 @@ async def trips_calendar_day(request: Request, year: int, month: int, day: int):
 
 @app.get("/api/trips/search", response_class=HTMLResponse)
 async def trips_search(request: Request, q: str = "", drive_mode: str = "",
-                        km_min: "float | None" = None, km_max: "float | None" = None,
-                        eff_min: "float | None" = None, eff_max: "float | None" = None,
-                        duration_min: "float | None" = None, duration_max: "float | None" = None,
+                        km_min: str = "", km_max: str = "",
+                        eff_min: str = "", eff_max: str = "",
+                        duration_min: str = "", duration_max: str = "",
                         date_from: str = "", date_to: str = "",
                         year: int = 0, month: int = 0):
     """Viaggi free-text + advanced-filter search (HTMX partial) — replaces the calendar with
     a flat, most-recent-first list of matches. No filter at all (search cleared) falls back
     to the calendar Month view instead of an empty list. km_min/km_max are typed in the
     user's own distance unit (the form label follows dist_unit()) and converted to km here,
-    same as a manually-entered odometer reading — search_trips itself is always metric."""
-    if not any((q.strip(), drive_mode.strip(), km_min is not None, km_max is not None,
-                eff_min is not None, eff_max is not None, duration_min is not None,
-                duration_max is not None, date_from.strip(), date_to.strip())):
+    same as a manually-entered odometer reading — search_trips itself is always metric.
+    The numeric fields arrive as strings (see _opt_float) — an empty advanced-filter field
+    must never 422 the whole request."""
+    n_km_min, n_km_max = _opt_float(km_min), _opt_float(km_max)
+    n_eff_min, n_eff_max = _opt_float(eff_min), _opt_float(eff_max)
+    n_duration_min, n_duration_max = _opt_float(duration_min), _opt_float(duration_max)
+    if not any((q.strip(), drive_mode.strip(), n_km_min is not None, n_km_max is not None,
+                n_eff_min is not None, n_eff_max is not None, n_duration_min is not None,
+                n_duration_max is not None, date_from.strip(), date_to.strip())):
         return _render_trips_calendar(request, year, month)
     lang = db_reader.get_language()
     trips = db_reader.search_trips(
         text=q, drive_mode=drive_mode,
-        km_min=units.dist_to_km(km_min), km_max=units.dist_to_km(km_max),
-        eff_min=eff_min, eff_max=eff_max, duration_min=duration_min, duration_max=duration_max,
+        km_min=units.dist_to_km(n_km_min), km_max=units.dist_to_km(n_km_max),
+        eff_min=n_eff_min, eff_max=n_eff_max, duration_min=n_duration_min, duration_max=n_duration_max,
         date_from=date_from, date_to=date_to)
     today = db_reader.today_local()
     return templates.TemplateResponse(request, "partials/trips_search_results.html", {
@@ -788,20 +810,25 @@ async def charges_calendar_day(request: Request, year: int, month: int, day: int
 
 @app.get("/api/charges/search", response_class=HTMLResponse)
 async def charges_search(request: Request, q: str = "", type: str = "",
-                          cost_min: "float | None" = None, cost_max: "float | None" = None,
-                          kwh_min: "float | None" = None, kwh_max: "float | None" = None,
+                          cost_min: str = "", cost_max: str = "",
+                          kwh_min: str = "", kwh_max: str = "",
                           date_from: str = "", date_to: str = "", station: str = "",
                           year: int = 0, month: int = 0):
     """Ricariche free-text + advanced-filter search (HTMX partial) — replaces the calendar
     with a flat, most-recent-first list of matches (see charge_card.html). No filter at all
-    (search cleared) falls back to the calendar Month view instead of an empty list."""
-    if not any((q.strip(), type.strip(), cost_min is not None, cost_max is not None,
-                kwh_min is not None, kwh_max is not None, date_from.strip(), date_to.strip())):
+    (search cleared) falls back to the calendar Month view instead of an empty list. The
+    numeric fields arrive as strings (see _opt_float) — an empty advanced-filter field must
+    never 422 the whole request (#175: htmx doesn't swap in a non-2xx response, so the
+    search silently did nothing whenever ANY unfilled number field was submitted)."""
+    n_cost_min, n_cost_max = _opt_float(cost_min), _opt_float(cost_max)
+    n_kwh_min, n_kwh_max = _opt_float(kwh_min), _opt_float(kwh_max)
+    if not any((q.strip(), type.strip(), n_cost_min is not None, n_cost_max is not None,
+                n_kwh_min is not None, n_kwh_max is not None, date_from.strip(), date_to.strip())):
         return _render_charges_calendar(request, year, month, station)
     lang = db_reader.get_language()
     charges = db_reader.search_charges(
-        text=q, charge_type=type, cost_min=cost_min, cost_max=cost_max,
-        kwh_min=kwh_min, kwh_max=kwh_max, date_from=date_from, date_to=date_to,
+        text=q, charge_type=type, cost_min=n_cost_min, cost_max=n_cost_max,
+        kwh_min=n_kwh_min, kwh_max=n_kwh_max, date_from=date_from, date_to=date_to,
         station=station or None)
     today = db_reader.today_local()
     return templates.TemplateResponse(request, "partials/charges_search_results.html", {

--- a/web/templates/charges.html
+++ b/web/templates/charges.html
@@ -11,10 +11,6 @@
   </div>
   {% if total %}
   <div class="shrink-0 flex items-center gap-2 flex-wrap justify-end">
-    <button type="button" id="collapse-all-charges"
-            class="inline-flex items-center gap-2 rounded-lg border border-slate-600 bg-slate-800/60 px-3 py-2 text-sm font-medium text-slate-200 hover:bg-slate-700 hover:border-slate-400/50 transition-all">
-      ⊟ {{ t('collapse_all') }}
-    </button>
     <a href="api/export/charges.csv" download
        class="inline-flex items-center gap-2 rounded-lg border border-slate-600 bg-slate-800/60 px-3 py-2 text-sm font-medium text-slate-200 hover:bg-slate-700 hover:border-brand/50 transition-all">
       <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M5,20H19V18H5M19,9H15V3H9V9H5L12,16L19,9Z"/></svg>
@@ -282,301 +278,67 @@ document.body.addEventListener('htmx:afterSwap', function (e) {
 </div>
 {% endif %}
 
-<!-- Grouped accordion -->
-{% if grouped %}
-<div class="space-y-3" id="charges-tree" data-ls-key="lm_charges_open">
-{% for year in grouped %}
-
-  <!-- YEAR -->
-  <details id="cy-{{ year.label }}" class="group">
-    <summary style="background:#1e293b;border:1px solid #334155;list-style:none"
-             class="flex items-center justify-between px-4 py-3 rounded-xl cursor-pointer select-none">
-      <div class="flex items-center gap-3">
-        <span class="group-open:rotate-90 text-slate-400" style="transition:transform .2s;display:inline-block">▶</span>
-        <span class="text-white font-bold text-lg">{{ year.label }}</span>
-      </div>
-      <div class="flex items-center flex-wrap justify-end gap-x-4 gap-y-1 text-sm">
-        <span class="text-slate-500 whitespace-nowrap">{{ year.count }} {{ t('session_inline_one') if year.count == 1 else t('session_inline_many') }}</span>
-        <span class="text-yellow-400 font-semibold whitespace-nowrap">{{ year.kwh }} kWh</span>
-        {% if year.has_cost %}
-        <span class="text-green-400 font-semibold whitespace-nowrap">{{ year.cost | money }}</span>
-        {% endif %}
-        <button type="button" onclick="lmCollapseDetails(this,event)" class="collapse-btn">⊟</button>
-      </div>
-    </summary>
-
-    <div class="ml-4 mt-2 space-y-2">
-    {% for month in year.months.values() %}
-
-      <!-- MONTH -->
-      <details id="cm-{{ month.label|replace(' ','_') }}" class="group/month">
-        <summary style="background:#0f172a;border:1px solid #1e293b;list-style:none"
-                 class="flex items-center justify-between px-4 py-2.5 rounded-lg cursor-pointer select-none">
-          <div class="flex items-center gap-3">
-            <span class="group-open/month:rotate-90 text-slate-500 text-sm" style="transition:transform .2s;display:inline-block">▶</span>
-            <span class="text-slate-200 font-semibold">{{ month.label }}</span>
-          </div>
-          <div class="flex items-center flex-wrap justify-end gap-x-4 gap-y-1 text-xs">
-            <span class="text-slate-500 whitespace-nowrap">{{ month.count }} {{ t('session_inline_one') if month.count == 1 else t('session_inline_many') }}</span>
-            <span class="text-yellow-400 font-medium whitespace-nowrap">{{ month.kwh }} kWh</span>
-            {% if month.has_cost %}
-            <span class="text-green-400 font-medium whitespace-nowrap">{{ month.cost | money }}</span>
-            {% endif %}
-            <button type="button" onclick="lmCollapseDetails(this,event)" class="collapse-btn">⊟</button>
-          </div>
-        </summary>
-
-        <div class="ml-4 mt-1.5 space-y-1.5">
-        {% for day in month.days.values() %}
-
-          <!-- DAY -->
-          <details id="cd-{{ day.label|replace(' ','_') }}" class="group/day">
-            <summary style="background:#0a1628;border:1px solid #1a2438;list-style:none"
-                     class="flex items-center justify-between px-3 py-2 rounded-lg cursor-pointer select-none">
-              <div class="flex items-center gap-2">
-                <span class="group-open/day:rotate-90 text-slate-600 text-xs" style="transition:transform .2s;display:inline-block">▶</span>
-                <span class="text-slate-300 text-sm font-medium">{{ day.label }}</span>
-                {# The count was spelled with an English rule ("session"/"sessions") on every language.
-                   Two keys instead, already cased per language — German capitalises the noun,
-                   the others don't. Slavic languages want a third form above four; the plural
-                   covers them, which is wrong for 5+ in Polish but no longer wrong in five
-                   languages at once. #}
-                <span class="text-slate-600 text-xs hidden sm:inline">— {{ day.count }} {{ t('session_inline_one') if day.count == 1 else t('session_inline_many') }}</span>
-              </div>
-              <div class="flex items-center flex-wrap justify-end gap-x-3 gap-y-1 text-xs">
-                <span class="text-yellow-400 font-medium whitespace-nowrap">{{ day.kwh }} kWh</span>
-                {% if day.has_cost %}
-                <span class="text-green-400 font-medium whitespace-nowrap">{{ day.cost | money }}</span>
-                {% endif %}
-              </div>
-            </summary>
-
-            <!-- Charge cards inside day -->
-            <div class="ml-4 mt-2 space-y-3">
-            {% for c in day.charges %}
-            {% set soc_start = c.start_soc or 0 %}
-            {% set soc_end   = c.end_soc   or 0 %}
-            {% set soc_delta = soc_end - soc_start %}
-
-            <div data-charge-id="{{ c.id }}" class="charge-card"
-                 style="background:#060e1a;border:1px solid #111c2e;border-radius:12px;padding:16px">
-
-              <!-- Header -->
-              <div class="flex items-center justify-between mb-4">
-                <div class="flex items-center gap-3">
-                  <div style="width:4px;height:40px;background:#fbbf24;border-radius:2px;flex-shrink:0"></div>
-                  <div>
-                    <div class="text-white font-semibold text-sm">
-                      {{ c.started_at[11:16] if c.started_at else '—' }}
-                      <span class="text-slate-500 font-normal">→ {{ c.ended_at[11:16] if c.ended_at else '' }}</span>
-                    </div>
-                    <div class="text-slate-500 text-xs mt-0.5">
-                      ⏱ {{ fmt_dur(c.duration_min) }}
-                      {% if c.max_power_kw %}· {{ "%.1f"|format(c.max_power_kw) }} kW peak{% endif %}
-                      {% set is_dc = c.charge_type == 'DC' or (c.charge_type is none and (c.max_power_kw or 0) > 11) %}
-                      · <span style="color:{% if is_dc %}#fb923c{% else %}#38bdf8{% endif %};font-weight:700">{% if is_dc %}DC{% else %}AC{% endif %}</span>
-                    </div>
-                    <div class="mt-0.5">{% with charge=c %}{% include "partials/charge_location.html" %}{% endwith %}</div>
-                    {% if c.reconstructed %}
-                    <div class="text-[11px] text-amber-400/90 mt-0.5" title="{{ t('charge_reconstructed_hint') }}">
-                      ✨ {{ t('charge_reconstructed') }}
-                    </div>
-                    {% endif %}
-                  </div>
-                </div>
-                <!-- Charge type selector (HTMX) -->
-                {% set ct = charge_types.get(c.location_type) %}
-                <div id="charge-type-{{ c.id }}" class="charge-type-selector">
-                  <div style="position:relative;display:inline-block">
-                    {% if ct %}
-                    <button onclick="document.getElementById('ct-menu-{{ c.id }}').classList.toggle('hidden')"
-                            style="background:{{ ct.color }}22;color:{{ ct.color }};border:1px solid {{ ct.color }}55;
-                                   padding:4px 10px;border-radius:20px;font-size:12px;font-weight:700;cursor:pointer;
-                                   display:flex;align-items:center;gap:5px">
-                      {{ ct.icon }} {{ ct.label }} <span style="font-size:9px;opacity:.7">▼</span>
-                    </button>
-                    {% else %}
-                    <button onclick="document.getElementById('ct-menu-{{ c.id }}').classList.toggle('hidden')"
-                            style="background:#f59e0b22;color:#f59e0b;border:1px solid #f59e0b88;
-                                   padding:4px 10px;border-radius:20px;font-size:12px;font-weight:700;cursor:pointer;
-                                   display:flex;align-items:center;gap:5px">
-                      ❓ {{ t('charge_unconfirmed') }} <span style="font-size:9px;opacity:.7">▼</span>
-                    </button>
-                    {% endif %}
-                    <div id="ct-menu-{{ c.id }}" class="hidden"
-                         style="position:absolute;right:0;top:calc(100% + 4px);z-index:50;
-                                background:#1e293b;border:1px solid #334155;border-radius:10px;
-                                padding:4px;min-width:155px;box-shadow:0 8px 24px rgba(0,0,0,.5)">
-                      {% if not ct %}
-                      <div style="padding:5px 10px 7px;margin-bottom:3px;font-size:11px;font-weight:700;
-                                  color:#fbbf24;border-bottom:1px solid #334155">{{ t('charge_confirm_q') }}</div>
-                      {% endif %}
-                      {% for key, info in charge_types.items() %}
-                      {% if key == 'MANUAL' %}
-                      <form hx-post="api/charges/{{ c.id }}/type"
-                            hx-target="#charge-type-{{ c.id }}"
-                            hx-swap="outerHTML"
-                            hx-on::after-request="document.getElementById('ct-menu-{{ c.id }}') && document.getElementById('ct-menu-{{ c.id }}').classList.add('hidden')"
-                            style="margin:0;border-top:1px solid #334155;margin-top:3px;padding-top:4px">
-                        <input type="hidden" name="location_type" value="MANUAL">
-                        <div style="display:flex;align-items:center;gap:6px;padding:5px 10px">
-                          <span style="color:{{ info.color }};font-size:13px">{{ info.icon }}</span>
-                          <input type="number" name="cost" step="0.01" min="0" placeholder="€"
-                                 value="{% if c.location_type == 'MANUAL' and c.cost %}{{ '%.2f'|format(c.cost) }}{% endif %}"
-                                 onclick="event.stopPropagation()"
-                                 style="width:72px;background:#0f172a;border:1px solid #334155;border-radius:6px;color:#fff;padding:4px 6px;font-size:13px">
-                          <button type="submit"
-                                  style="margin-left:auto;background:{{ info.color }}22;color:{{ info.color }};border:1px solid {{ info.color }}55;border-radius:6px;padding:4px 10px;font-size:12px;font-weight:700;cursor:pointer">
-                            {% if c.location_type == 'MANUAL' %}✓{% else %}OK{% endif %}
-                          </button>
-                        </div>
-                      </form>
-                      {% else %}
-                      <form hx-post="api/charges/{{ c.id }}/type"
-                            hx-target="#charge-type-{{ c.id }}"
-                            hx-swap="outerHTML"
-                            hx-on::after-request="document.getElementById('ct-menu-{{ c.id }}') && document.getElementById('ct-menu-{{ c.id }}').classList.add('hidden')"
-                            style="margin:0">
-                        <input type="hidden" name="location_type" value="{{ key }}">
-                        <button type="submit"
-                                style="width:100%;text-align:left;padding:7px 12px;border-radius:7px;font-size:13px;
-                                       cursor:pointer;background:{% if c.location_type == key %}{{ info.color }}22{% else %}transparent{% endif %};
-                                       color:{{ info.color }};border:none;display:flex;align-items:center;gap:8px">
-                          {{ info.icon }} {{ info.label }}
-                          {% if c.location_type == key %}<span style="margin-left:auto;font-size:10px">✓</span>{% endif %}
-                        </button>
-                      </form>
-                      {% endif %}
-                      {% endfor %}
-                    </div>
-                  </div>
-                  {% if c.location_type == 'HOME' %}
-                  {# #120: mark a home charge as free (e.g. self-produced solar). Stays HOME, cost 0. #}
-                  <form hx-post="api/charges/{{ c.id }}/free" hx-target="#charge-type-{{ c.id }}" hx-swap="outerHTML"
-                        style="margin:0;display:inline-block;vertical-align:top;margin-left:6px">
-                    <input type="hidden" name="is_free" value="{% if c.is_free %}0{% else %}1{% endif %}">
-                    <button type="submit" title="{{ t('charge_free_hint') }}"
-                            style="background:{% if c.is_free %}#a3e63522{% else %}transparent{% endif %};
-                                   color:{% if c.is_free %}#a3e635{% else %}#64748b{% endif %};
-                                   border:1px solid {% if c.is_free %}#a3e63566{% else %}#334155{% endif %};
-                                   padding:4px 10px;border-radius:20px;font-size:12px;font-weight:700;cursor:pointer;
-                                   display:inline-flex;align-items:center;gap:5px;white-space:nowrap">
-                      🆓 {{ t('charge_free') }}{% if c.is_free %} ✓{% endif %}
-                    </button>
-                  </form>
-                  {% endif %}
-                </div>
-              </div>
-
-              <!-- SOC bar -->
-              <div class="mb-3">
-                <div class="flex justify-between text-xs mb-1.5">
-                  <span class="text-slate-500">SOC</span>
-                  <span class="text-white font-medium">
-                    {{ "%.1f"|format(soc_start) }}%
-                    <span class="text-slate-600 mx-1">→</span>
-                    {{ "%.1f"|format(soc_end) }}%
-                    <span class="text-yellow-400 ml-1 font-bold">+{{ "%.1f"|format(soc_delta) }}%</span>
-                  </span>
-                </div>
-                <div style="position:relative;height:12px;background:#1e293b;border-radius:6px;overflow:hidden">
-                  <div style="position:absolute;left:0;top:0;height:100%;width:{{ soc_start }}%;background:#334155"></div>
-                  <div class="soc-bar" style="position:absolute;left:{{ soc_start }}%;top:0;height:100%;width:{{ soc_delta }}%;background:linear-gradient(90deg,#fbbf24,#f59e0b)"></div>
-                </div>
-                <div class="flex justify-between text-xs text-slate-700 mt-1">
-                  <span>0%</span><span>25%</span><span>50%</span><span>75%</span><span>100%</span>
-                </div>
-              </div>
-
-              <!-- Stats -->
-              <div class="grid grid-cols-3 gap-2 mt-3">
-                {% set show_wb = c.ac_energy_kwh and c.location_type == 'HOME' %}
-                <div style="background:#0f172a;border-radius:8px;padding:8px 12px">
-                  <div class="stat-label" style="font-size:10px">{{ t('energy') }}</div>
-                  <div style="font-size:16px;font-weight:700;color:#fbbf24">
-                    +{{ "%.1f"|format((c.ac_energy_kwh if show_wb else c.energy_added_kwh) or 0) }}<span style="font-size:11px;color:#94a3b8;font-weight:400"> kWh</span>
-                    {% if show_wb %}<span style="font-size:10px;color:#60a5fa;font-weight:400" title="{{ t('wallbox_billed_help') }}"> 🔌 {{ t('wallbox_billed') }}</span>{% else %}<span style="font-size:10px;color:#94a3b8;font-weight:400" title="{{ t('energy_in_battery_help') }}"> 🔋 {{ t('energy_in_battery') }} (DC)</span>{% endif %}
-                  </div>
-                  {% if show_wb %}
-                  <div style="font-size:10px;color:#94a3b8;margin-top:3px" title="{{ t('wallbox_billed_help') }}">
-                    {# Efficiency >100% is physically impossible — it means the ΔSoC-based DC figure is
-                       inflated (BMS snap-to-full on 100%-ending charges recorded before the fix), so
-                       hide the % rather than show nonsense. #}
-                    {% set _eff = (100 * c.energy_added_kwh / c.ac_energy_kwh) if c.energy_added_kwh else 0 %}
-                    🔋 {{ "%.1f"|format(c.energy_added_kwh or 0) }} kWh {{ t('energy_in_battery') }} (DC){% if c.energy_added_kwh and _eff <= 100 %} · {{ t('efficiency') }} {{ "%.0f"|format(_eff) }}%{% endif %}
-                  </div>
-                  {% endif %}
-                </div>
-                <div style="background:#0f172a;border-radius:8px;padding:8px 12px">
-                  <div class="stat-label" style="font-size:10px">{{ t('soc_gain') }}</div>
-                  <div style="font-size:16px;font-weight:700;color:white">
-                    +{{ "%.1f"|format(soc_delta) }}<span style="font-size:11px;color:#94a3b8;font-weight:400"> %</span>
-                  </div>
-                </div>
-                <div style="background:#0f172a;border-radius:8px;padding:8px 12px">
-                  <div class="stat-label" style="font-size:10px">{{ t('cost') }}</div>
-                  <div id="cost-{{ c.id }}" style="font-size:16px;font-weight:700" class="{% if c.cost %}text-green-400{% else %}text-slate-600{% endif %}">
-                    {% if c.cost %}{{ c.cost | money }}{% else %}—{% endif %}
-                    {% set _billed = (c.ac_energy_kwh if (c.location_type == 'HOME' and c.ac_energy_kwh) else c.energy_added_kwh) or 0 %}
-                    {% if c.cost and _billed > 0 %}<div style="font-size:11px;color:#94a3b8;font-weight:400">{{ (c.cost / _billed) | money }}/kWh</div>{% endif %}
-                  </div>
-                </div>
-              </div>
-
-              <!-- User note (#107) — free-text context the raw data can't capture -->
-              <div class="mt-3">
-                <label class="stat-label" style="font-size:10px">📝 {{ t('user_note') }}</label>
-                <form class="mt-1" hx-post="api/charges/{{ c.id }}/note"
-                      hx-target="#cnote-msg-{{ c.id }}" hx-swap="innerHTML"
-                      hx-on::after-request="if(event.detail.successful){var m=document.getElementById('cnote-msg-{{ c.id }}');setTimeout(function(){if(m)m.textContent='';},2500);}">
-                  <textarea name="note" rows="2" maxlength="1000"
-                            placeholder="{{ t('note_ph_charge') }}"
-                            style="width:100%;background:#0f172a;border:1px solid #334155;border-radius:8px;padding:8px 10px;font-size:12px;color:#e2e8f0;resize:vertical">{{ c.note or '' }}</textarea>
-                  <div class="flex items-center gap-2 mt-1">
-                    <button type="submit"
-                            style="background:#1e293b;border:1px solid #334155;border-radius:6px;padding:3px 12px;font-size:11px;color:#94a3b8;cursor:pointer"
-                            onmouseover="this.style.borderColor='#38bdf8';this.style.color='#e2e8f0'"
-                            onmouseout="this.style.borderColor='#334155';this.style.color='#94a3b8'">{{ t('note_save') }}</button>
-                    <span id="cnote-msg-{{ c.id }}" class="text-xs text-green-400"></span>
-                  </div>
-                </form>
-              </div>
-
-              <div class="flex justify-end mt-2">
-                <button hx-delete="api/charges/{{ c.id }}" hx-confirm="{{ t('charge_delete_confirm') }}"
-                        style="background:transparent;border:none;cursor:pointer;font-size:11px;color:#64748b"
-                        onmouseover="this.style.color='#f87171'" onmouseout="this.style.color='#64748b'">
-                  🗑 {{ t('charge_delete') }}</button>
-              </div>
-
-              <!-- Power curve (expandable, lazy-loaded on first open) -->
-              <details class="mt-3">
-                <summary hx-get="api/charge/{{ c.id }}/power-chart"
-                         hx-trigger="click once"
-                         hx-target="#pchart-{{ c.id }}"
-                         hx-swap="innerHTML"
-                         style="cursor:pointer;color:#38bdf8;font-size:12px;list-style:none;user-select:none">
-                  📈 {{ t('power_curve') }}
-                </summary>
-                <div id="pchart-{{ c.id }}" class="mt-2">
-                  <div class="text-xs text-slate-500 py-2">…</div>
-                </div>
-              </details>
-
-            </div>
-            {% endfor %}
-            </div>
-
-          </details>
-        {% endfor %}
-        </div>
-
-      </details>
-    {% endfor %}
+{% if total %}
+<!-- Search + advanced filters -->
+<div class="card mb-6">
+  <form id="charges-search-form"
+        hx-get="api/charges/search"
+        hx-target="#charges-calendar-month-wrap" hx-swap="innerHTML"
+        hx-trigger="keyup changed delay:400ms from:#charges-search-q, change"
+        class="space-y-3">
+    <input type="hidden" name="year" value="{{ cal_year }}">
+    <input type="hidden" name="month" value="{{ cal_month }}">
+    {% if station %}<input type="hidden" name="station" value="{{ station }}">{% endif %}
+    <div class="flex flex-col sm:flex-row sm:items-center gap-2">
+      <input id="charges-search-q" type="text" name="q" autocomplete="off"
+             placeholder="🔍 {{ t('charges_search_placeholder') }}"
+             class="flex-1 min-w-0 bg-slate-800 border border-slate-600 text-white text-sm rounded-lg px-3 py-2 focus:outline-none focus:border-brand">
+      <button type="button" onclick="document.getElementById('charges-adv-filters').classList.toggle('hidden')"
+              class="text-xs text-slate-400 hover:text-white border border-slate-600 rounded-lg px-3 py-2 whitespace-nowrap w-full sm:w-auto">
+        ⚙ {{ t('charges_search_advanced') }}
+      </button>
     </div>
+    <div id="charges-adv-filters" class="hidden grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-7 gap-2 pt-2 border-t border-slate-700/60">
+      <select name="type" class="bg-slate-800 border border-slate-600 text-white text-xs rounded-lg px-2 py-1.5">
+        <option value="">{{ t('charges_search_all_types') }}</option>
+        {% for key, info in charge_types.items() %}
+        <option value="{{ key }}">{{ info.icon }} {{ info.label }}</option>
+        {% endfor %}
+      </select>
+      <input type="date" name="date_from" title="{{ t('charges_search_date_from') }}"
+             class="bg-slate-800 border border-slate-600 text-white text-xs rounded-lg px-2 py-1.5">
+      <input type="date" name="date_to" title="{{ t('charges_search_date_to') }}"
+             class="bg-slate-800 border border-slate-600 text-white text-xs rounded-lg px-2 py-1.5">
+      <input type="number" step="0.01" min="0" name="kwh_min" placeholder="{{ t('charges_search_kwh_min') }}"
+             class="bg-slate-800 border border-slate-600 text-white text-xs rounded-lg px-2 py-1.5">
+      <input type="number" step="0.01" min="0" name="kwh_max" placeholder="{{ t('charges_search_kwh_max') }}"
+             class="bg-slate-800 border border-slate-600 text-white text-xs rounded-lg px-2 py-1.5">
+      <input type="number" step="0.01" min="0" name="cost_min" placeholder="{{ t('charges_search_cost_min') }}"
+             class="bg-slate-800 border border-slate-600 text-white text-xs rounded-lg px-2 py-1.5">
+      <input type="number" step="0.01" min="0" name="cost_max" placeholder="{{ t('charges_search_cost_max') }}"
+             class="bg-slate-800 border border-slate-600 text-white text-xs rounded-lg px-2 py-1.5">
+    </div>
+  </form>
+</div>
 
-  </details>
-{% endfor %}
+{% if cal_years and cal_years|length > 1 %}
+<!-- Year jump — only years with actual charges, so it never lists empty years -->
+<div class="flex items-center gap-2 flex-wrap mb-4">
+  {% for y in cal_years %}
+  <button type="button"
+          hx-get="api/charges/calendar?year={{ y }}&month={{ cal_month }}{% if station %}&station={{ station }}{% endif %}"
+          hx-target="#charges-calendar-month-wrap" hx-swap="innerHTML"
+          class="px-3 py-1.5 rounded-lg text-sm font-medium border border-slate-600 text-slate-300 hover:border-brand hover:text-white transition-colors">
+    {{ y }}
+  </button>
+  {% endfor %}
+</div>
+{% endif %}
+
+<div class="card mb-6" id="charges-calendar-month-wrap"
+     hx-get="api/charges/calendar?year={{ cal_year }}&month={{ cal_month }}{% if station %}&station={{ station }}{% endif %}{% if cal_open_day %}&open_day={{ cal_open_day }}{% endif %}"
+     hx-trigger="load" hx-swap="innerHTML">
+  <div class="text-center text-slate-500 py-10">…</div>
 </div>
 
 {% else %}
@@ -588,51 +350,27 @@ document.body.addEventListener('htmx:afterSwap', function (e) {
 {% endif %}
 
 <script>
-const LS_KEY = 'lm_charges_open';
 const HIGHLIGHT = {{ highlight }};
 
-const saved = JSON.parse(localStorage.getItem(LS_KEY) || '{}');
-document.querySelectorAll('#charges-tree details').forEach(el => {
-  if (el.id in saved) {
-    el.open = saved[el.id];
-  } else {
-    el.open = el.id.startsWith('cy-') || el.id.startsWith('cm-');
-  }
-  el.addEventListener('toggle', () => {
-    const st = JSON.parse(localStorage.getItem(LS_KEY) || '{}');
-    st[el.id] = el.open;
-    localStorage.setItem(LS_KEY, JSON.stringify(st));
-  });
-});
-
-// Collapse all
-document.getElementById('collapse-all-charges')?.addEventListener('click', () => {
-  const st = JSON.parse(localStorage.getItem(LS_KEY) || '{}');
-  document.querySelectorAll('#charges-tree details').forEach(el => {
-    el.open = false;
-    st[el.id] = false;
-  });
-  localStorage.setItem(LS_KEY, JSON.stringify(st));
-});
-
+// A charge reached via ?highlight=<id> (e.g. a map popup) lands on the right month/day
+// server-side (charges_page resolves it and passes cal_open_day) — once that first HTMX
+// load renders the day's cards, find it, style it and scroll it into view.
 if (HIGHLIGHT) {
-  const card = document.querySelector(`[data-charge-id="${HIGHLIGHT}"]`);
-  if (card) {
-    let el = card.parentElement;
-    while (el) {
-      if (el.tagName === 'DETAILS') el.open = true;
-      el = el.parentElement;
+  document.body.addEventListener('htmx:afterSwap', function onSwap(e) {
+    if (!e.target || e.target.id !== 'charges-calendar-month-wrap') return;
+    const card = document.querySelector(`[data-charge-id="${HIGHLIGHT}"]`);
+    if (card) {
+      card.style.border    = '1px solid #fbbf2455';
+      card.style.boxShadow = 'inset 3px 0 0 #fbbf24';
+      requestAnimationFrame(() => card.scrollIntoView({ behavior: 'smooth', block: 'center' }));
+      document.body.removeEventListener('htmx:afterSwap', onSwap);
     }
-    card.style.border     = '1px solid #fbbf2455';
-    card.style.boxShadow  = 'inset 3px 0 0 #fbbf24';
-    requestAnimationFrame(() => card.scrollIntoView({ behavior: 'smooth', block: 'center' }));
-  }
+  });
 }
 
 // Auto-refresh the history when a charge completes. The live panel (#charging-live-panel) polls
 // every 30s; when its state flips charging→not-charging a charge has just ended, so reload once to
-// surface the new completed-charge card + updated totals (the history list itself is static). The
-// tree's open/collapsed state survives the reload via localStorage above, so it is non-disruptive.
+// surface the new completed-charge card + updated totals.
 (function () {
   const isCharging = () => {
     const m = document.getElementById('charging-state');

--- a/web/templates/partials/charge_card.html
+++ b/web/templates/partials/charge_card.html
@@ -1,0 +1,214 @@
+{# Single charge card — used by the day accordion (charges.html), the calendar day-drawer
+   and the search results list. Expects `c` (a charge dict, localized like get_charges_grouped
+   produces) plus the page-level `t`, `charge_types`, `ico` already in the including template's
+   context (Jinja includes share the parent scope by default). #}
+{% set soc_start = c.start_soc or 0 %}
+{% set soc_end   = c.end_soc   or 0 %}
+{% set soc_delta = soc_end - soc_start %}
+
+<div data-charge-id="{{ c.id }}" class="charge-card"
+     style="background:#060e1a;border:1px solid #111c2e;border-radius:12px;padding:16px">
+
+  <!-- Header -->
+  <div class="flex items-center justify-between mb-4">
+    <div class="flex items-center gap-3">
+      <div style="width:4px;height:40px;background:#fbbf24;border-radius:2px;flex-shrink:0"></div>
+      <div>
+        <div class="text-white font-semibold text-sm">
+          {{ c.started_at[11:16] if c.started_at else '—' }}
+          <span class="text-slate-500 font-normal">→ {{ c.ended_at[11:16] if c.ended_at else '' }}</span>
+        </div>
+        <div class="text-slate-500 text-xs mt-0.5">
+          ⏱ {{ fmt_dur(c.duration_min) }}
+          {% if c.max_power_kw %}· {{ "%.1f"|format(c.max_power_kw) }} kW peak{% endif %}
+          {% set is_dc = c.charge_type == 'DC' or (c.charge_type is none and (c.max_power_kw or 0) > 11) %}
+          · <span style="color:{% if is_dc %}#fb923c{% else %}#38bdf8{% endif %};font-weight:700">{% if is_dc %}DC{% else %}AC{% endif %}</span>
+        </div>
+        <div class="mt-0.5">{% with charge=c %}{% include "partials/charge_location.html" %}{% endwith %}</div>
+        {% if c.reconstructed %}
+        <div class="text-[11px] text-amber-400/90 mt-0.5" title="{{ t('charge_reconstructed_hint') }}">
+          ✨ {{ t('charge_reconstructed') }}
+        </div>
+        {% endif %}
+      </div>
+    </div>
+    <!-- Charge type selector (HTMX) -->
+    {% set ct = charge_types.get(c.location_type) %}
+    <div id="charge-type-{{ c.id }}" class="charge-type-selector">
+      <div style="position:relative;display:inline-block">
+        {% if ct %}
+        <button onclick="document.getElementById('ct-menu-{{ c.id }}').classList.toggle('hidden')"
+                style="background:{{ ct.color }}22;color:{{ ct.color }};border:1px solid {{ ct.color }}55;
+                       padding:4px 10px;border-radius:20px;font-size:12px;font-weight:700;cursor:pointer;
+                       display:flex;align-items:center;gap:5px">
+          {{ ct.icon }} {{ ct.label }} <span style="font-size:9px;opacity:.7">▼</span>
+        </button>
+        {% else %}
+        <button onclick="document.getElementById('ct-menu-{{ c.id }}').classList.toggle('hidden')"
+                style="background:#f59e0b22;color:#f59e0b;border:1px solid #f59e0b88;
+                       padding:4px 10px;border-radius:20px;font-size:12px;font-weight:700;cursor:pointer;
+                       display:flex;align-items:center;gap:5px">
+          ❓ {{ t('charge_unconfirmed') }} <span style="font-size:9px;opacity:.7">▼</span>
+        </button>
+        {% endif %}
+        <div id="ct-menu-{{ c.id }}" class="hidden"
+             style="position:absolute;right:0;top:calc(100% + 4px);z-index:50;
+                    background:#1e293b;border:1px solid #334155;border-radius:10px;
+                    padding:4px;min-width:155px;box-shadow:0 8px 24px rgba(0,0,0,.5)">
+          {% if not ct %}
+          <div style="padding:5px 10px 7px;margin-bottom:3px;font-size:11px;font-weight:700;
+                      color:#fbbf24;border-bottom:1px solid #334155">{{ t('charge_confirm_q') }}</div>
+          {% endif %}
+          {% for key, info in charge_types.items() %}
+          {% if key == 'MANUAL' %}
+          <form hx-post="api/charges/{{ c.id }}/type"
+                hx-target="#charge-type-{{ c.id }}"
+                hx-swap="outerHTML"
+                hx-on::after-request="document.getElementById('ct-menu-{{ c.id }}') && document.getElementById('ct-menu-{{ c.id }}').classList.add('hidden')"
+                style="margin:0;border-top:1px solid #334155;margin-top:3px;padding-top:4px">
+            <input type="hidden" name="location_type" value="MANUAL">
+            <div style="display:flex;align-items:center;gap:6px;padding:5px 10px">
+              <span style="color:{{ info.color }};font-size:13px">{{ info.icon }}</span>
+              <input type="number" name="cost" step="0.01" min="0" placeholder="€"
+                     value="{% if c.location_type == 'MANUAL' and c.cost %}{{ '%.2f'|format(c.cost) }}{% endif %}"
+                     onclick="event.stopPropagation()"
+                     style="width:72px;background:#0f172a;border:1px solid #334155;border-radius:6px;color:#fff;padding:4px 6px;font-size:13px">
+              <button type="submit"
+                      style="margin-left:auto;background:{{ info.color }}22;color:{{ info.color }};border:1px solid {{ info.color }}55;border-radius:6px;padding:4px 10px;font-size:12px;font-weight:700;cursor:pointer">
+                {% if c.location_type == 'MANUAL' %}✓{% else %}OK{% endif %}
+              </button>
+            </div>
+          </form>
+          {% else %}
+          <form hx-post="api/charges/{{ c.id }}/type"
+                hx-target="#charge-type-{{ c.id }}"
+                hx-swap="outerHTML"
+                hx-on::after-request="document.getElementById('ct-menu-{{ c.id }}') && document.getElementById('ct-menu-{{ c.id }}').classList.add('hidden')"
+                style="margin:0">
+            <input type="hidden" name="location_type" value="{{ key }}">
+            <button type="submit"
+                    style="width:100%;text-align:left;padding:7px 12px;border-radius:7px;font-size:13px;
+                           cursor:pointer;background:{% if c.location_type == key %}{{ info.color }}22{% else %}transparent{% endif %};
+                           color:{{ info.color }};border:none;display:flex;align-items:center;gap:8px">
+              {{ info.icon }} {{ info.label }}
+              {% if c.location_type == key %}<span style="margin-left:auto;font-size:10px">✓</span>{% endif %}
+            </button>
+          </form>
+          {% endif %}
+          {% endfor %}
+        </div>
+      </div>
+      {% if c.location_type == 'HOME' %}
+      {# #120: mark a home charge as free (e.g. self-produced solar). Stays HOME, cost 0. #}
+      <form hx-post="api/charges/{{ c.id }}/free" hx-target="#charge-type-{{ c.id }}" hx-swap="outerHTML"
+            style="margin:0;display:inline-block;vertical-align:top;margin-left:6px">
+        <input type="hidden" name="is_free" value="{% if c.is_free %}0{% else %}1{% endif %}">
+        <button type="submit" title="{{ t('charge_free_hint') }}"
+                style="background:{% if c.is_free %}#a3e63522{% else %}transparent{% endif %};
+                       color:{% if c.is_free %}#a3e635{% else %}#64748b{% endif %};
+                       border:1px solid {% if c.is_free %}#a3e63566{% else %}#334155{% endif %};
+                       padding:4px 10px;border-radius:20px;font-size:12px;font-weight:700;cursor:pointer;
+                       display:inline-flex;align-items:center;gap:5px;white-space:nowrap">
+          🆓 {{ t('charge_free') }}{% if c.is_free %} ✓{% endif %}
+        </button>
+      </form>
+      {% endif %}
+    </div>
+  </div>
+
+  <!-- SOC bar -->
+  <div class="mb-3">
+    <div class="flex justify-between text-xs mb-1.5">
+      <span class="text-slate-500">SOC</span>
+      <span class="text-white font-medium">
+        {{ "%.1f"|format(soc_start) }}%
+        <span class="text-slate-600 mx-1">→</span>
+        {{ "%.1f"|format(soc_end) }}%
+        <span class="text-yellow-400 ml-1 font-bold">+{{ "%.1f"|format(soc_delta) }}%</span>
+      </span>
+    </div>
+    <div style="position:relative;height:12px;background:#1e293b;border-radius:6px;overflow:hidden">
+      <div style="position:absolute;left:0;top:0;height:100%;width:{{ soc_start }}%;background:#334155"></div>
+      <div class="soc-bar" style="position:absolute;left:{{ soc_start }}%;top:0;height:100%;width:{{ soc_delta }}%;background:linear-gradient(90deg,#fbbf24,#f59e0b)"></div>
+    </div>
+    <div class="flex justify-between text-xs text-slate-700 mt-1">
+      <span>0%</span><span>25%</span><span>50%</span><span>75%</span><span>100%</span>
+    </div>
+  </div>
+
+  <!-- Stats -->
+  <div class="grid grid-cols-3 gap-2 mt-3">
+    {% set show_wb = c.ac_energy_kwh and c.location_type == 'HOME' %}
+    <div style="background:#0f172a;border-radius:8px;padding:8px 12px">
+      <div class="stat-label" style="font-size:10px">{{ t('energy') }}</div>
+      <div style="font-size:16px;font-weight:700;color:#fbbf24">
+        +{{ "%.1f"|format((c.ac_energy_kwh if show_wb else c.energy_added_kwh) or 0) }}<span style="font-size:11px;color:#94a3b8;font-weight:400"> kWh</span>
+        {% if show_wb %}<span style="font-size:10px;color:#60a5fa;font-weight:400" title="{{ t('wallbox_billed_help') }}"> 🔌 {{ t('wallbox_billed') }}</span>{% else %}<span style="font-size:10px;color:#94a3b8;font-weight:400" title="{{ t('energy_in_battery_help') }}"> 🔋 {{ t('energy_in_battery') }} (DC)</span>{% endif %}
+      </div>
+      {% if show_wb %}
+      <div style="font-size:10px;color:#94a3b8;margin-top:3px" title="{{ t('wallbox_billed_help') }}">
+        {# Efficiency >100% is physically impossible — it means the ΔSoC-based DC figure is
+           inflated (BMS snap-to-full on 100%-ending charges recorded before the fix), so
+           hide the % rather than show nonsense. #}
+        {% set _eff = (100 * c.energy_added_kwh / c.ac_energy_kwh) if c.energy_added_kwh else 0 %}
+        🔋 {{ "%.1f"|format(c.energy_added_kwh or 0) }} kWh {{ t('energy_in_battery') }} (DC){% if c.energy_added_kwh and _eff <= 100 %} · {{ t('efficiency') }} {{ "%.0f"|format(_eff) }}%{% endif %}
+      </div>
+      {% endif %}
+    </div>
+    <div style="background:#0f172a;border-radius:8px;padding:8px 12px">
+      <div class="stat-label" style="font-size:10px">{{ t('soc_gain') }}</div>
+      <div style="font-size:16px;font-weight:700;color:white">
+        +{{ "%.1f"|format(soc_delta) }}<span style="font-size:11px;color:#94a3b8;font-weight:400"> %</span>
+      </div>
+    </div>
+    <div style="background:#0f172a;border-radius:8px;padding:8px 12px">
+      <div class="stat-label" style="font-size:10px">{{ t('cost') }}</div>
+      <div id="cost-{{ c.id }}" style="font-size:16px;font-weight:700" class="{% if c.cost %}text-green-400{% else %}text-slate-600{% endif %}">
+        {% if c.cost %}{{ c.cost | money }}{% else %}—{% endif %}
+        {% set _billed = (c.ac_energy_kwh if (c.location_type == 'HOME' and c.ac_energy_kwh) else c.energy_added_kwh) or 0 %}
+        {% if c.cost and _billed > 0 %}<div style="font-size:11px;color:#94a3b8;font-weight:400">{{ (c.cost / _billed) | money }}/kWh</div>{% endif %}
+      </div>
+    </div>
+  </div>
+
+  <!-- User note (#107) — free-text context the raw data can't capture -->
+  <div class="mt-3">
+    <label class="stat-label" style="font-size:10px">📝 {{ t('user_note') }}</label>
+    <form class="mt-1" hx-post="api/charges/{{ c.id }}/note"
+          hx-target="#cnote-msg-{{ c.id }}" hx-swap="innerHTML"
+          hx-on::after-request="if(event.detail.successful){var m=document.getElementById('cnote-msg-{{ c.id }}');setTimeout(function(){if(m)m.textContent='';},2500);}">
+      <textarea name="note" rows="2" maxlength="1000"
+                placeholder="{{ t('note_ph_charge') }}"
+                style="width:100%;background:#0f172a;border:1px solid #334155;border-radius:8px;padding:8px 10px;font-size:12px;color:#e2e8f0;resize:vertical">{{ c.note or '' }}</textarea>
+      <div class="flex items-center gap-2 mt-1">
+        <button type="submit"
+                style="background:#1e293b;border:1px solid #334155;border-radius:6px;padding:3px 12px;font-size:11px;color:#94a3b8;cursor:pointer"
+                onmouseover="this.style.borderColor='#38bdf8';this.style.color='#e2e8f0'"
+                onmouseout="this.style.borderColor='#334155';this.style.color='#94a3b8'">{{ t('note_save') }}</button>
+        <span id="cnote-msg-{{ c.id }}" class="text-xs text-green-400"></span>
+      </div>
+    </form>
+  </div>
+
+  <div class="flex justify-end mt-2">
+    <button hx-delete="api/charges/{{ c.id }}" hx-confirm="{{ t('charge_delete_confirm') }}"
+            style="background:transparent;border:none;cursor:pointer;font-size:11px;color:#64748b"
+            onmouseover="this.style.color='#f87171'" onmouseout="this.style.color='#64748b'">
+      🗑 {{ t('charge_delete') }}</button>
+  </div>
+
+  <!-- Power curve (expandable, lazy-loaded on first open) -->
+  <details class="mt-3">
+    <summary hx-get="api/charge/{{ c.id }}/power-chart"
+             hx-trigger="click once"
+             hx-target="#pchart-{{ c.id }}"
+             hx-swap="innerHTML"
+             style="cursor:pointer;color:#38bdf8;font-size:12px;list-style:none;user-select:none">
+      📈 {{ t('power_curve') }}
+    </summary>
+    <div id="pchart-{{ c.id }}" class="mt-2">
+      <div class="text-xs text-slate-500 py-2">…</div>
+    </div>
+  </details>
+
+</div>

--- a/web/templates/partials/charges_calendar_day.html
+++ b/web/templates/partials/charges_calendar_day.html
@@ -1,0 +1,2 @@
+{# GET /api/charges/calendar/day response — the Month view's day-drawer content. #}
+{% include "partials/charges_calendar_day_content.html" %}

--- a/web/templates/partials/charges_calendar_day_content.html
+++ b/web/templates/partials/charges_calendar_day_content.html
@@ -1,0 +1,17 @@
+{# Day header + charge cards — shared by the day-drawer's own endpoint (charges_calendar_day.html)
+   and the Month view's initial "open on this day" render (charges_calendar_month.html, via
+   ?open_day=). Expects `charges` (list) and `day_label` (str) in scope, plus the page-level
+   `t`/`charge_types`/`fmt_dur`. #}
+{% if charges %}
+<div class="mb-3 flex items-center justify-between flex-wrap gap-2">
+  <span class="text-white font-semibold">{{ day_label }}</span>
+  <span class="text-slate-500 text-xs">{{ charges|length }} {{ t('session_inline_one') if charges|length == 1 else t('session_inline_many') }}</span>
+</div>
+<div class="space-y-3">
+  {% for c in charges %}
+  {% include "partials/charge_card.html" %}
+  {% endfor %}
+</div>
+{% else %}
+<div class="text-center text-slate-500 text-sm py-6">{{ t('charges_calendar_pick_day') }}</div>
+{% endif %}

--- a/web/templates/partials/charges_calendar_month.html
+++ b/web/templates/partials/charges_calendar_month.html
@@ -1,0 +1,76 @@
+{# GET /api/charges/calendar response — the Ricariche "calendar" Month view. Self-replacing:
+   the prev/next/today nav buttons target THIS SAME #charges-calendar-month container with
+   hx-swap="outerHTML", so navigating months also resets the day-drawer below (a day open in
+   the old month rarely makes sense in the new one). Day cells with charges instead target only
+   #charges-day-drawer — clicking a day never re-fetches or re-renders the grid. #}
+<div id="charges-calendar-month">
+  <div class="flex items-center justify-between mb-4">
+    <button type="button" title="{{ t('charges_calendar_prev') }}"
+            hx-get="api/charges/calendar?year={{ prev_year }}&month={{ prev_month }}{% if station %}&station={{ station }}{% endif %}"
+            hx-target="#charges-calendar-month" hx-swap="outerHTML"
+            class="w-9 h-9 flex items-center justify-center rounded-lg border border-slate-600 text-slate-300 hover:border-brand hover:text-white transition-colors">◀</button>
+    <div class="text-center">
+      <div class="text-white font-bold text-lg leading-tight">{{ month_label }}</div>
+      {% if not (year == today.year and month == today.month) %}
+      <button type="button"
+              hx-get="api/charges/calendar{% if station %}?station={{ station }}{% endif %}"
+              hx-target="#charges-calendar-month" hx-swap="outerHTML"
+              class="text-xs text-brand hover:underline">{{ t('charges_calendar_today') }}</button>
+      {% endif %}
+    </div>
+    <button type="button" title="{{ t('charges_calendar_next') }}"
+            hx-get="api/charges/calendar?year={{ next_year }}&month={{ next_month }}{% if station %}&station={{ station }}{% endif %}"
+            hx-target="#charges-calendar-month" hx-swap="outerHTML"
+            class="w-9 h-9 flex items-center justify-center rounded-lg border border-slate-600 text-slate-300 hover:border-brand hover:text-white transition-colors">▶</button>
+  </div>
+
+  {% if total.count %}
+  <div class="flex items-center justify-center gap-4 text-sm mb-4 flex-wrap">
+    <span class="text-slate-400">{{ total.count }} {{ t('session_inline_one') if total.count == 1 else t('session_inline_many') }}</span>
+    <span class="text-yellow-400 font-semibold">{{ total.kwh }} kWh</span>
+    {% if total.has_cost %}<span class="text-green-400 font-semibold">{{ total.cost | money }}</span>{% endif %}
+  </div>
+  {% endif %}
+
+  <div class="grid grid-cols-7 gap-1 sm:gap-1.5 lg:gap-2 text-center text-[10px] sm:text-xs lg:text-sm text-slate-500 mb-1">
+    {% for wd in weekday_abbrs %}<div>{{ wd }}</div>{% endfor %}
+  </div>
+
+  <div class="grid grid-cols-7 gap-1 sm:gap-1.5 lg:gap-2">
+    {% for week in weeks %}
+      {% for cell in week %}
+        {% if cell is none %}
+        <div></div>
+        {% else %}
+        {% set is_today = (year == today.year and month == today.month and cell.day == today.day) %}
+        {% if cell.count %}
+        <button type="button"
+                hx-get="api/charges/calendar/day?year={{ year }}&month={{ month }}&day={{ cell.day }}{% if station %}&station={{ station }}{% endif %}"
+                hx-target="#charges-day-drawer" hx-swap="innerHTML"
+                class="aspect-square rounded-lg border flex flex-col items-center justify-center gap-0.5 lg:gap-1 cursor-pointer hover:border-brand transition-colors"
+                style="background:#0f172a;border-color:{% if is_today %}#fbbf24{% else %}#1e293b{% endif %}">
+          <span class="text-[11px] sm:text-sm lg:text-lg {% if is_today %}text-yellow-400 font-bold{% else %}text-slate-300{% endif %}">{{ cell.day }}</span>
+          <span class="text-[9px] sm:text-[11px] lg:text-sm text-yellow-400 font-semibold leading-none">{{ cell.kwh }}</span>
+          <span class="text-[8px] sm:text-[10px] lg:text-xs text-slate-500 leading-none">{{ cell.count }}⚡</span>
+        </button>
+        {% else %}
+        <div class="aspect-square rounded-lg flex items-center justify-center"
+             style="background:#0a1220;border:1px solid {% if is_today %}#fbbf2455{% else %}#111c2e{% endif %}">
+          <span class="text-[11px] sm:text-sm lg:text-lg {% if is_today %}text-yellow-400 font-bold{% else %}text-slate-600{% endif %}">{{ cell.day }}</span>
+        </div>
+        {% endif %}
+        {% endif %}
+      {% endfor %}
+    {% endfor %}
+  </div>
+
+  <div id="charges-day-drawer" class="mt-4">
+    {% if open_day_charges is defined %}
+      {% with charges = open_day_charges, day_label = open_day_label %}
+        {% include "partials/charges_calendar_day_content.html" %}
+      {% endwith %}
+    {% else %}
+    <div class="text-center text-slate-500 text-sm py-6">{{ t('charges_calendar_pick_day') }}</div>
+    {% endif %}
+  </div>
+</div>

--- a/web/templates/partials/charges_search_results.html
+++ b/web/templates/partials/charges_search_results.html
@@ -1,8 +1,20 @@
 {# GET /api/charges/search response — replaces #charges-calendar-month-wrap with a flat,
    most-recent-first list of matches. Cleared filters fall back to the calendar server-side
-   (see charges_search in main.py), so this template only ever renders actual search state. #}
+   (see charges_search in main.py), so this template only ever renders actual search state.
+   A visible header + "clear" button make it unmistakable that this IS a different mode
+   from the calendar — swapping the list in silently (same card, no reset control) made it
+   easy to miss that a filter had actually applied at all (#175). #}
+<div class="mb-3 flex items-center justify-between flex-wrap gap-2">
+  <span class="text-white font-semibold">🔍 {{ charges|length }} {{ t('charges_search_results') }}</span>
+  <button type="button"
+          onclick="document.getElementById('charges-search-form').reset(); document.getElementById('charges-adv-filters').classList.add('hidden');"
+          hx-get="api/charges/calendar?year={{ year }}&month={{ month }}{% if station %}&station={{ station }}{% endif %}"
+          hx-target="#charges-calendar-month-wrap" hx-swap="innerHTML"
+          class="text-xs text-brand hover:underline whitespace-nowrap">
+    ✕ {{ t('charges_search_clear') }}
+  </button>
+</div>
 {% if charges %}
-<div class="mb-3 text-slate-400 text-sm">{{ charges|length }} {{ t('charges_search_results') }}</div>
 <div class="space-y-3">
   {% for c in charges %}
   {% include "partials/charge_card.html" %}

--- a/web/templates/partials/charges_search_results.html
+++ b/web/templates/partials/charges_search_results.html
@@ -1,0 +1,16 @@
+{# GET /api/charges/search response — replaces #charges-calendar-month-wrap with a flat,
+   most-recent-first list of matches. Cleared filters fall back to the calendar server-side
+   (see charges_search in main.py), so this template only ever renders actual search state. #}
+{% if charges %}
+<div class="mb-3 text-slate-400 text-sm">{{ charges|length }} {{ t('charges_search_results') }}</div>
+<div class="space-y-3">
+  {% for c in charges %}
+  {% include "partials/charge_card.html" %}
+  {% endfor %}
+</div>
+{% else %}
+<div class="text-center text-slate-500 py-10">
+  <div class="text-3xl mb-2">🔍</div>
+  <div>{{ t('charges_search_no_results') }}</div>
+</div>
+{% endif %}

--- a/web/templates/partials/trip_merge_candidates.html
+++ b/web/templates/partials/trip_merge_candidates.html
@@ -1,0 +1,40 @@
+{# GET /api/trips/merge-candidates response — dedicated list of trip pairs eligible for
+   merging, replacing #trips-calendar-month-wrap. Independent of whichever month/day is
+   currently browsed in the calendar (see main.py's docstring for why). Reuses the SAME
+   #merge-modal / #merge-modal-body (defined once in trips.html, outside this swapped area)
+   for the confirm-and-preview step, exactly like the old accordion's inline connectors did. #}
+<div class="flex items-center justify-between gap-3 flex-wrap mb-4">
+  <span class="text-white font-semibold">{{ t('merge_eligible') }}</span>
+  <label class="text-xs text-slate-300 inline-flex items-center gap-2 whitespace-nowrap">
+    {{ t('merge_max_gap') }}: <output class="text-yellow-400 font-semibold">{{ gap }}</output> min
+    <input type="range" name="gap" min="{{ merge_gap_min }}" max="{{ merge_gap_max }}" step="5" value="{{ gap }}"
+           hx-get="api/trips/merge-candidates" hx-trigger="change"
+           hx-target="#trips-calendar-month-wrap" hx-swap="innerHTML"
+           class="accent-yellow-400 w-36 align-middle">
+  </label>
+</div>
+
+{% if candidates %}
+<div class="space-y-4">
+  {% for pair in candidates %}
+  <div class="rounded-xl border border-yellow-500/20 bg-yellow-400/5 p-2">
+    {% with trip = pair.a %}{% include "partials/trip_row.html" %}{% endwith %}
+    <div class="flex justify-center my-1">
+      <button type="button"
+              hx-get="api/trips/merge-preview?a={{ pair.a.id }}&b={{ pair.b.id }}&gap={{ merge_gap_max }}"
+              hx-target="#merge-modal-body" hx-swap="innerHTML"
+              onclick="document.getElementById('merge-modal').style.display='flex'"
+              class="inline-flex items-center gap-1.5 rounded-md border border-yellow-500/50 bg-yellow-400/10 text-yellow-400 px-2.5 py-1 text-[11px] font-semibold hover:bg-yellow-400/15">
+        🔗 {{ t('merge_join') }} <span class="font-normal opacity-70">· {{ t('merge_stop') }} {{ pair.gap_min }}′</span>
+      </button>
+    </div>
+    {% with trip = pair.b %}{% include "partials/trip_row.html" %}{% endwith %}
+  </div>
+  {% endfor %}
+</div>
+{% else %}
+<div class="text-center text-slate-500 py-10">
+  <div class="text-3xl mb-2">🔗</div>
+  <div>{{ t('merge_none') }}</div>
+</div>
+{% endif %}

--- a/web/templates/partials/trip_row.html
+++ b/web/templates/partials/trip_row.html
@@ -1,0 +1,66 @@
+{# Single trip row — reused by the day-drawer, search results and the merge-candidates list.
+   Expects `trip` in scope, plus the page-level `t`/`fmt_dur`/`is_reev`/`research` already in
+   context (Jinja includes share the parent scope). `eff_cls` and the `dist`/`eff`/`nice`
+   filters are global (see main.py), no extra wiring needed.
+   Unmerge is unconditional on trip.is_merged now — previously gated behind the accordion's
+   "merge mode" toggle, but that toggle's whole-page connector scan doesn't fit a
+   load-one-day-at-a-time calendar, so a merged trip's own row now always offers to split it
+   back (reversible, low-risk enough not to need a confirmation step first). #}
+{% set used = (trip.start_soc or 0) - (trip.end_soc or 0) %}
+<a href="trips/{{ trip.id }}" data-trip-id="{{ trip.id }}" class="trip-row">
+
+  {% if trip.reconstructed %}
+  <div class="trip-thumb flex items-center justify-center text-amber-400/70 text-lg"
+       title="{{ t('trip_reconstructed_hint') }}">✨</div>
+  {% else %}
+  <img class="trip-thumb" loading="lazy" alt="" src="trips/{{ trip.id }}/route.svg">
+  {% endif %}
+
+  <div class="min-w-0 flex-1">
+    <div class="text-white text-sm font-medium">
+      {{ trip.started_at[11:16] if trip.started_at else '—' }}
+      <span class="text-slate-500 font-normal text-xs ml-1">
+        → {{ trip.ended_at[11:16] if trip.ended_at else '' }}
+      </span>
+      {% if trip.is_merged %}<span style="font-size:10px" class="text-yellow-400" title="{{ trip.merged_count }} {{ t('merge_segments') }}">🔗</span>{% endif %}
+      {% if trip.reconstructed %}<span style="font-size:10px" class="text-amber-400/90 ml-1" title="{{ t('trip_reconstructed_hint') }}">✨ {{ t('trip_reconstructed') }}</span>{% endif %}
+    </div>
+    <div class="text-slate-500 text-xs">{{ fmt_dur(trip.duration_min) }}{% if trip.is_merged %} · {{ t('driving_only') }}{% endif %}</div>
+  </div>
+
+  <div class="hidden sm:flex flex-col items-end gap-1 flex-shrink-0">
+    <div class="soc-mini" title="{{ '%.0f'|format(trip.start_soc or 0) }}% → {{ '%.0f'|format(trip.end_soc or 0) }}%">
+      <i class="soc-rem"  style="width:{{ trip.end_soc or 0 }}%"></i>
+      <i class="soc-used" style="left:{{ trip.end_soc or 0 }}%;width:{{ used if used > 0 else 0 }}%"></i>
+    </div>
+    <div class="text-slate-500 text-[11px]">
+      {{ "%.0f"|format(trip.start_soc or 0) }}→{{ "%.0f"|format(trip.end_soc or 0) }}%
+    </div>
+  </div>
+
+  <div class="text-right flex-shrink-0" style="min-width:84px">
+    <div class="text-white text-sm font-bold">{{ (trip.distance_km or 0) | dist(1) }}</div>
+    {% if trip.efficiency_kwh_100km %}
+    <span class="eff-pill {{ eff_cls(trip.efficiency_kwh_100km) }} mt-0.5">
+      {{ trip.efficiency_kwh_100km | eff }}
+    </span>
+    {% endif %}
+    {% if is_reev and research and trip.engine_ran %}
+    {# REEV Phase C — flag an engine-on trip with its fuel consumption #}
+    <span class="block mt-0.5 text-amber-400 text-[11px] font-semibold" title="{{ t('reev_engine_ran') }}">⛽ {% if trip.fuel_l_100km is not none %}{{ trip.fuel_l_100km | nice }} L/100km{% else %}{{ trip.fuel_used_l | nice }} L{% endif %}</span>
+    {% endif %}
+    {% if trip.ec_pending %}
+    <span class="block mt-0.5 text-amber-400 text-[11px] font-medium" title="{{ t('ec_provisional') }}">⏳ {{ t('ec_provisional_short') }}</span>
+    {% endif %}
+  </div>
+
+</a>
+{% if trip.is_merged %}
+<div class="merge-sep" style="padding:0 0 4px 56px">
+  <button type="button"
+          class="inline-flex items-center gap-1 rounded-md border border-slate-600 text-slate-300 px-2 py-0.5 text-[11px] font-medium hover:border-red-500 hover:text-red-400"
+          hx-post="api/trips/unmerge?parent={{ trip.id }}" hx-confirm="{{ t('unmerge_confirm') }}" hx-swap="none">
+    ↩️ {{ t('unmerge_btn') }}
+  </button>
+</div>
+{% endif %}

--- a/web/templates/partials/trips_calendar_day.html
+++ b/web/templates/partials/trips_calendar_day.html
@@ -1,0 +1,2 @@
+{# GET /api/trips/calendar/day response — the Month view's day-drawer content. #}
+{% include "partials/trips_calendar_day_content.html" %}

--- a/web/templates/partials/trips_calendar_day_content.html
+++ b/web/templates/partials/trips_calendar_day_content.html
@@ -1,0 +1,17 @@
+{# Day header + trip rows — shared by the day-drawer's own endpoint (trips_calendar_day.html)
+   and the Month view's initial "open on this day" render (trips_calendar_month.html, via
+   ?open_day=). Expects `trips` (list) and `day_label` (str) in scope, plus the page-level
+   `t`/`fmt_dur`/`is_reev`/`research`. #}
+{% if trips %}
+<div class="mb-3 flex items-center justify-between flex-wrap gap-2">
+  <span class="text-white font-semibold">{{ day_label }}</span>
+  <span class="text-slate-500 text-xs">{{ trips|length }} {{ t('trip_singular') if trips|length == 1 else t('trips_plural') }}</span>
+</div>
+<div class="space-y-1">
+  {% for trip in trips %}
+  {% include "partials/trip_row.html" %}
+  {% endfor %}
+</div>
+{% else %}
+<div class="text-center text-slate-500 text-sm py-6">{{ t('trips_calendar_pick_day') }}</div>
+{% endif %}

--- a/web/templates/partials/trips_calendar_month.html
+++ b/web/templates/partials/trips_calendar_month.html
@@ -1,0 +1,76 @@
+{# GET /api/trips/calendar response — the Viaggi "calendar" Month view. Self-replacing: the
+   prev/next/today nav buttons target THIS SAME #trips-calendar-month container with
+   hx-swap="outerHTML", so navigating months also resets the day-drawer below. Day cells with
+   trips instead target only #trips-day-drawer — clicking a day never re-fetches the grid. #}
+<div id="trips-calendar-month">
+  <div class="flex items-center justify-between mb-4">
+    <button type="button" title="{{ t('charges_calendar_prev') }}"
+            hx-get="api/trips/calendar?year={{ prev_year }}&month={{ prev_month }}"
+            hx-target="#trips-calendar-month" hx-swap="outerHTML"
+            class="w-9 h-9 flex items-center justify-center rounded-lg border border-slate-600 text-slate-300 hover:border-brand hover:text-white transition-colors">◀</button>
+    <div class="text-center">
+      <div class="text-white font-bold text-lg leading-tight">{{ month_label }}</div>
+      {% if not (year == today.year and month == today.month) %}
+      <button type="button"
+              hx-get="api/trips/calendar"
+              hx-target="#trips-calendar-month" hx-swap="outerHTML"
+              class="text-xs text-brand hover:underline">{{ t('charges_calendar_today') }}</button>
+      {% endif %}
+    </div>
+    <button type="button" title="{{ t('charges_calendar_next') }}"
+            hx-get="api/trips/calendar?year={{ next_year }}&month={{ next_month }}"
+            hx-target="#trips-calendar-month" hx-swap="outerHTML"
+            class="w-9 h-9 flex items-center justify-center rounded-lg border border-slate-600 text-slate-300 hover:border-brand hover:text-white transition-colors">▶</button>
+  </div>
+
+  {% if total.count %}
+  <div class="flex items-center justify-center gap-4 text-sm mb-4 flex-wrap">
+    <span class="text-slate-400">{{ total.count }} {{ t('trip_singular') if total.count == 1 else t('trips_plural') }}</span>
+    <span class="text-white font-semibold">{{ total.km | dist(1) }}</span>
+    {% if total.avg_eff %}<span class="eff-pill {{ eff_cls(total.avg_eff) }}">{{ total.avg_eff | eff }}</span>{% endif %}
+    {% if total.cost %}<span class="text-slate-300 font-semibold">{{ total.cost | money }}</span>{% endif %}
+  </div>
+  {% endif %}
+
+  <div class="grid grid-cols-7 gap-1 sm:gap-1.5 lg:gap-2 text-center text-[10px] sm:text-xs lg:text-sm text-slate-500 mb-1">
+    {% for wd in weekday_abbrs %}<div>{{ wd }}</div>{% endfor %}
+  </div>
+
+  <div class="grid grid-cols-7 gap-1 sm:gap-1.5 lg:gap-2">
+    {% for week in weeks %}
+      {% for cell in week %}
+        {% if cell is none %}
+        <div></div>
+        {% else %}
+        {% set is_today = (year == today.year and month == today.month and cell.day == today.day) %}
+        {% if cell.count %}
+        <button type="button"
+                hx-get="api/trips/calendar/day?year={{ year }}&month={{ month }}&day={{ cell.day }}"
+                hx-target="#trips-day-drawer" hx-swap="innerHTML"
+                class="aspect-square rounded-lg border flex flex-col items-center justify-center gap-0.5 lg:gap-1 cursor-pointer hover:border-brand transition-colors"
+                style="background:#0f172a;border-color:{% if is_today %}#fbbf24{% else %}#1e293b{% endif %}">
+          <span class="text-[11px] sm:text-sm lg:text-lg {% if is_today %}text-yellow-400 font-bold{% else %}text-slate-300{% endif %}">{{ cell.day }}</span>
+          <span class="text-[9px] sm:text-[11px] lg:text-sm text-white font-semibold leading-none">{{ cell.km | dist(0) }}</span>
+          <span class="text-[8px] sm:text-[10px] lg:text-xs text-slate-500 leading-none">{{ cell.count }}🚗</span>
+        </button>
+        {% else %}
+        <div class="aspect-square rounded-lg flex items-center justify-center"
+             style="background:#0a1220;border:1px solid {% if is_today %}#fbbf2455{% else %}#111c2e{% endif %}">
+          <span class="text-[11px] sm:text-sm lg:text-lg {% if is_today %}text-yellow-400 font-bold{% else %}text-slate-600{% endif %}">{{ cell.day }}</span>
+        </div>
+        {% endif %}
+        {% endif %}
+      {% endfor %}
+    {% endfor %}
+  </div>
+
+  <div id="trips-day-drawer" class="mt-4">
+    {% if open_day_trips is defined %}
+      {% with trips = open_day_trips, day_label = open_day_label %}
+        {% include "partials/trips_calendar_day_content.html" %}
+      {% endwith %}
+    {% else %}
+    <div class="text-center text-slate-500 text-sm py-6">{{ t('trips_calendar_pick_day') }}</div>
+    {% endif %}
+  </div>
+</div>

--- a/web/templates/partials/trips_search_results.html
+++ b/web/templates/partials/trips_search_results.html
@@ -1,0 +1,16 @@
+{# GET /api/trips/search response — replaces #trips-calendar-month-wrap with a flat,
+   most-recent-first list of matches. Cleared filters fall back to the calendar server-side
+   (see trips_search in main.py), so this template only ever renders actual search state. #}
+{% if trips %}
+<div class="mb-3 text-slate-400 text-sm">{{ trips|length }} {{ t('charges_search_results') }}</div>
+<div class="space-y-1">
+  {% for trip in trips %}
+  {% include "partials/trip_row.html" %}
+  {% endfor %}
+</div>
+{% else %}
+<div class="text-center text-slate-500 py-10">
+  <div class="text-3xl mb-2">🔍</div>
+  <div>{{ t('trips_search_no_results') }}</div>
+</div>
+{% endif %}

--- a/web/templates/partials/trips_search_results.html
+++ b/web/templates/partials/trips_search_results.html
@@ -1,8 +1,19 @@
 {# GET /api/trips/search response — replaces #trips-calendar-month-wrap with a flat,
    most-recent-first list of matches. Cleared filters fall back to the calendar server-side
-   (see trips_search in main.py), so this template only ever renders actual search state. #}
+   (see trips_search in main.py), so this template only ever renders actual search state.
+   A visible header + "clear" button, same as Ricariche's search results (#175) — swapping
+   the list in silently made it easy to miss that a filter had applied at all. #}
+<div class="mb-3 flex items-center justify-between flex-wrap gap-2">
+  <span class="text-white font-semibold">🔍 {{ trips|length }} {{ t('charges_search_results') }}</span>
+  <button type="button"
+          onclick="document.getElementById('trips-search-form').reset(); document.getElementById('trips-adv-filters').classList.add('hidden');"
+          hx-get="api/trips/calendar?year={{ year }}&month={{ month }}"
+          hx-target="#trips-calendar-month-wrap" hx-swap="innerHTML"
+          class="text-xs text-brand hover:underline whitespace-nowrap">
+    ✕ {{ t('charges_search_clear') }}
+  </button>
+</div>
 {% if trips %}
-<div class="mb-3 text-slate-400 text-sm">{{ trips|length }} {{ t('charges_search_results') }}</div>
 <div class="space-y-1">
   {% for trip in trips %}
   {% include "partials/trip_row.html" %}

--- a/web/templates/partials/wallbox_calendar_day.html
+++ b/web/templates/partials/wallbox_calendar_day.html
@@ -1,0 +1,2 @@
+{# GET /api/wallbox/calendar/day response — the Month view's day-drawer content. #}
+{% include "partials/wallbox_calendar_day_content.html" %}

--- a/web/templates/partials/wallbox_calendar_day_content.html
+++ b/web/templates/partials/wallbox_calendar_day_content.html
@@ -1,0 +1,44 @@
+{# Day header + session rows — shared by the day-drawer's own endpoint
+   (wallbox_calendar_day.html) and the Month view's initial "open on this day" render
+   (wallbox_calendar_month.html, via ?open_day=). Expects `sessions` (list, each already
+   carrying ac_kwh/dc_kwh/eff — see main.py's _wallbox_day_sessions) and `day_label` (str). #}
+{% macro kwh_pair(ac, dc, eff) %}
+  <div class="flex items-center gap-3 text-xs">
+    <span class="text-emerald-400 font-medium">{% if ac %}{{ ac | nice }}<span class="text-slate-500 ml-0.5">AC</span>{% else %}<span class="text-slate-600">—</span>{% endif %}</span>
+    <span class="text-amber-400 font-medium">{% if dc %}{{ dc | nice }}<span class="text-slate-500 ml-0.5">DC</span>{% else %}<span class="text-slate-600">—</span>{% endif %}</span>
+    <span class="font-semibold {% if eff is none %}text-slate-600{% elif eff >= 88 %}text-green-400{% elif eff >= 80 %}text-yellow-400{% else %}text-red-400{% endif %}">{% if eff is not none %}{{ eff | nice }}%{% else %}—{% endif %}</span>
+  </div>
+{% endmacro %}
+
+{% if sessions %}
+<div class="mb-2 flex items-center justify-between flex-wrap gap-2">
+  <span class="text-white font-semibold">{{ day_label }}</span>
+</div>
+<div class="flex items-center flex-wrap gap-x-4 gap-y-1 text-[11px] mb-3 pb-2 border-b border-slate-800">
+  <span class="text-emerald-400 font-medium">● {{ t('wb_th_ac') }}</span>
+  <span class="text-amber-400 font-medium">● {{ t('wb_th_dc') }}</span>
+  <span class="text-slate-300 font-medium">% {{ t('wb_th_eff') }}</span>
+  <span class="text-slate-500">— {{ t('wallbox_compare_legend') }}</span>
+</div>
+<div class="space-y-2">
+{% for s in sessions %}
+  <details class="group/sess">
+    <summary hx-get="api/wallbox/compare-chart?charge_id={{ s.id }}"
+             hx-trigger="click once" hx-target="#wbc-{{ s.id }}" hx-swap="innerHTML"
+             style="background:#060e1a;border:1px solid #111c2e;list-style:none"
+             class="flex items-center justify-between px-3 py-2 rounded-lg cursor-pointer select-none">
+      <div class="flex items-center gap-2">
+        <span class="group-open/sess:rotate-90 text-slate-600 text-xs" style="transition:transform .2s;display:inline-block">📈</span>
+        <span class="text-slate-300 text-sm">{{ s.time }}</span>
+      </div>
+      {{ kwh_pair(s.ac_kwh, s.dc_kwh, s.eff) }}
+    </summary>
+    <div id="wbc-{{ s.id }}" class="mt-2">
+      <div class="text-xs text-slate-500 py-2">…</div>
+    </div>
+  </details>
+{% endfor %}
+</div>
+{% else %}
+<div class="text-center text-slate-500 text-sm py-6">{{ t('wallbox_calendar_pick_day') }}</div>
+{% endif %}

--- a/web/templates/partials/wallbox_calendar_month.html
+++ b/web/templates/partials/wallbox_calendar_month.html
@@ -1,0 +1,77 @@
+{# GET /api/wallbox/calendar response — the Wallbox "calendar" Month view. Self-replacing:
+   the prev/next/today nav buttons target THIS SAME #wallbox-calendar-month container with
+   hx-swap="outerHTML". Day cells with sessions instead target only #wallbox-day-drawer —
+   clicking a day never re-fetches the grid, and only THAT day's sessions get their AC/DC
+   comparison computed (a live Home Assistant history call each — see main.py). #}
+<div id="wallbox-calendar-month">
+  <div class="flex items-center justify-between mb-4">
+    <button type="button" title="{{ t('charges_calendar_prev') }}"
+            hx-get="api/wallbox/calendar?year={{ prev_year }}&month={{ prev_month }}"
+            hx-target="#wallbox-calendar-month" hx-swap="outerHTML"
+            class="w-9 h-9 flex items-center justify-center rounded-lg border border-slate-600 text-slate-300 hover:border-brand hover:text-white transition-colors">◀</button>
+    <div class="text-center">
+      <div class="text-white font-bold text-lg leading-tight">{{ month_label }}</div>
+      {% if not (year == today.year and month == today.month) %}
+      <button type="button"
+              hx-get="api/wallbox/calendar"
+              hx-target="#wallbox-calendar-month" hx-swap="outerHTML"
+              class="text-xs text-brand hover:underline">{{ t('charges_calendar_today') }}</button>
+      {% endif %}
+    </div>
+    <button type="button" title="{{ t('charges_calendar_next') }}"
+            hx-get="api/wallbox/calendar?year={{ next_year }}&month={{ next_month }}"
+            hx-target="#wallbox-calendar-month" hx-swap="outerHTML"
+            class="w-9 h-9 flex items-center justify-center rounded-lg border border-slate-600 text-slate-300 hover:border-brand hover:text-white transition-colors">▶</button>
+  </div>
+
+  {% if total.count %}
+  <div class="flex items-center justify-center gap-4 text-sm mb-4 flex-wrap">
+    <span class="text-slate-400">{{ total.count }} {{ t('session_inline_one') if total.count == 1 else t('session_inline_many') }}</span>
+    <span class="text-emerald-400 font-semibold">{{ total.ac | nice }} <span class="text-slate-500 font-normal">AC</span></span>
+    <span class="text-amber-400 font-semibold">{{ total.dc | nice }} <span class="text-slate-500 font-normal">DC</span></span>
+    {% if total.eff is not none %}<span class="text-slate-300 font-semibold">{{ total.eff | nice }}%</span>{% endif %}
+  </div>
+  {% endif %}
+
+  <div class="grid grid-cols-7 gap-1 sm:gap-1.5 lg:gap-2 text-center text-[10px] sm:text-xs lg:text-sm text-slate-500 mb-1">
+    {% for wd in weekday_abbrs %}<div>{{ wd }}</div>{% endfor %}
+  </div>
+
+  <div class="grid grid-cols-7 gap-1 sm:gap-1.5 lg:gap-2">
+    {% for week in weeks %}
+      {% for cell in week %}
+        {% if cell is none %}
+        <div></div>
+        {% else %}
+        {% set is_today = (year == today.year and month == today.month and cell.day == today.day) %}
+        {% if cell.count %}
+        <button type="button"
+                hx-get="api/wallbox/calendar/day?year={{ year }}&month={{ month }}&day={{ cell.day }}"
+                hx-target="#wallbox-day-drawer" hx-swap="innerHTML"
+                class="aspect-square rounded-lg border flex flex-col items-center justify-center gap-0.5 lg:gap-1 cursor-pointer hover:border-brand transition-colors"
+                style="background:#0f172a;border-color:{% if is_today %}#fbbf24{% else %}#1e293b{% endif %}">
+          <span class="text-[11px] sm:text-sm lg:text-lg {% if is_today %}text-yellow-400 font-bold{% else %}text-slate-300{% endif %}">{{ cell.day }}</span>
+          <span class="text-[9px] sm:text-[11px] lg:text-sm text-emerald-400 font-semibold leading-none">{{ cell.ac | nice }}</span>
+          <span class="text-[8px] sm:text-[10px] lg:text-xs text-slate-500 leading-none">{{ cell.count }}🔌</span>
+        </button>
+        {% else %}
+        <div class="aspect-square rounded-lg flex items-center justify-center"
+             style="background:#0a1220;border:1px solid {% if is_today %}#fbbf2455{% else %}#111c2e{% endif %}">
+          <span class="text-[11px] sm:text-sm lg:text-lg {% if is_today %}text-yellow-400 font-bold{% else %}text-slate-600{% endif %}">{{ cell.day }}</span>
+        </div>
+        {% endif %}
+        {% endif %}
+      {% endfor %}
+    {% endfor %}
+  </div>
+
+  <div id="wallbox-day-drawer" class="mt-4">
+    {% if open_day_sessions is defined %}
+      {% with sessions = open_day_sessions, day_label = open_day_label %}
+        {% include "partials/wallbox_calendar_day_content.html" %}
+      {% endwith %}
+    {% else %}
+    <div class="text-center text-slate-500 text-sm py-6">{{ t('wallbox_calendar_pick_day') }}</div>
+    {% endif %}
+  </div>
+</div>

--- a/web/templates/trips.html
+++ b/web/templates/trips.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 {% block title %}Trips — LeapMotor Mate{% endblock %}
 
-{# Efficiency → pill colour class #}
-{% macro eff_cls(e) %}{% if e < 18 %}eff-good{% elif e < 22 %}eff-mid{% else %}eff-bad{% endif %}{% endmacro %}
+{# eff_cls is now a global Jinja function (main.py's _eff_cls) — shared with trip_row.html.
+   eff_hex (below) stays template-local: only the hero tile above needs a raw colour value. #}
 {# Efficiency → hex colour (for non-pill values) #}
 {% macro eff_hex(e) %}{% if e < 18 %}#4ade80{% elif e < 22 %}#facc15{% else %}#f87171{% endif %}{% endmacro %}
 
@@ -14,14 +14,6 @@
   </div>
   {% if total %}
   <div class="shrink-0 flex items-center gap-2 flex-wrap justify-end">
-    <button type="button" id="merge-toggle"
-            class="inline-flex items-center gap-2 rounded-lg border border-slate-600 bg-slate-800/60 px-3 py-2 text-sm font-medium text-slate-200 hover:bg-slate-700 hover:border-yellow-500/50 transition-all">
-      🔗 {{ t('merge_mode') }}
-    </button>
-    <button type="button" id="collapse-all-trips"
-            class="inline-flex items-center gap-2 rounded-lg border border-slate-600 bg-slate-800/60 px-3 py-2 text-sm font-medium text-slate-200 hover:bg-slate-700 hover:border-slate-400/50 transition-all">
-      ⊟ {{ t('collapse_all') }}
-    </button>
     <a href="api/export/trips.csv" download
        class="inline-flex items-center gap-2 rounded-lg border border-slate-600 bg-slate-800/60 px-3 py-2 text-sm font-medium text-slate-200 hover:bg-slate-700 hover:border-brand/50 transition-all">
       <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M5,20H19V18H5M19,9H15V3H9V9H5L12,16L19,9Z"/></svg>
@@ -29,18 +21,6 @@
     </a>
   </div>
   {% endif %}
-</div>
-
-<!-- Merge-mode bar (revealed by the 🔗 toggle). The connectors below are filtered live by this slider. -->
-<div id="merge-bar" style="display:none"
-     class="items-center gap-x-4 gap-y-2 flex-wrap mb-5 rounded-lg border border-yellow-500/30 bg-yellow-400/5 px-4 py-3">
-  <span class="text-sm font-medium text-yellow-400 inline-flex items-center gap-1">🔗 {{ t('merge_mode') }}</span>
-  <span class="text-xs text-slate-400 flex-1 min-w-[160px]">{{ t('merge_help') }}</span>
-  <label class="text-xs text-slate-300 inline-flex items-center gap-2 whitespace-nowrap">
-    {{ t('merge_max_gap') }}: <output id="merge-gap-out" class="text-yellow-400 font-semibold">{{ merge_gap_default }}</output> min
-    <input id="merge-gap" type="range" min="{{ merge_gap_min }}" max="{{ merge_gap_max }}" step="5"
-           value="{{ merge_gap_default }}" class="accent-yellow-400 w-36 align-middle">
-  </label>
 </div>
 
 {% if summary and summary.count %}
@@ -92,186 +72,76 @@
 </div>
 {% endif %}
 
-<!-- ── Trips (year / month / day tree) ──────────────────────────── -->
-{% if grouped %}
-<section>
-  <div class="space-y-3" id="trips-tree" data-ls-key="lm_trips_open">
-  {% for year in grouped %}
+{% if total %}
+<!-- Search + advanced filters -->
+<div class="card mb-6">
+  <form id="trips-search-form"
+        hx-get="api/trips/search"
+        hx-target="#trips-calendar-month-wrap" hx-swap="innerHTML"
+        hx-trigger="keyup changed delay:400ms from:#trips-search-q, change"
+        class="space-y-3">
+    <input type="hidden" name="year" value="{{ cal_year }}">
+    <input type="hidden" name="month" value="{{ cal_month }}">
+    <div class="flex flex-col sm:flex-row sm:items-center gap-2">
+      <input id="trips-search-q" type="text" name="q" autocomplete="off"
+             placeholder="🔍 {{ t('trips_search_placeholder') }}"
+             class="flex-1 min-w-0 bg-slate-800 border border-slate-600 text-white text-sm rounded-lg px-3 py-2 focus:outline-none focus:border-brand">
+      <button type="button" onclick="document.getElementById('trips-adv-filters').classList.toggle('hidden')"
+              class="text-xs text-slate-400 hover:text-white border border-slate-600 rounded-lg px-3 py-2 whitespace-nowrap w-full sm:w-auto">
+        ⚙ {{ t('charges_search_advanced') }}
+      </button>
+    </div>
+    <div id="trips-adv-filters" class="hidden grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-2 pt-2 border-t border-slate-700/60">
+      <select name="drive_mode" class="bg-slate-800 border border-slate-600 text-white text-xs rounded-lg px-2 py-1.5">
+        <option value="">{{ t('trips_search_all_modes') }}</option>
+        <option value="comfort">{{ t('mode_comfort') }}</option>
+        <option value="normal">{{ t('mode_normal') }}</option>
+        <option value="sport">{{ t('mode_sport') }}</option>
+      </select>
+      <input type="date" name="date_from" title="{{ t('charges_search_date_from') }}"
+             class="bg-slate-800 border border-slate-600 text-white text-xs rounded-lg px-2 py-1.5">
+      <input type="date" name="date_to" title="{{ t('charges_search_date_to') }}"
+             class="bg-slate-800 border border-slate-600 text-white text-xs rounded-lg px-2 py-1.5">
+      <input type="number" step="0.1" min="0" name="km_min" placeholder="{{ t('trips_search_km_min') }} ({{ dist_unit() }})"
+             class="bg-slate-800 border border-slate-600 text-white text-xs rounded-lg px-2 py-1.5">
+      <input type="number" step="0.1" min="0" name="km_max" placeholder="{{ t('trips_search_km_max') }} ({{ dist_unit() }})"
+             class="bg-slate-800 border border-slate-600 text-white text-xs rounded-lg px-2 py-1.5">
+      <input type="number" step="1" min="0" name="duration_min" placeholder="{{ t('trips_search_duration_min') }}"
+             class="bg-slate-800 border border-slate-600 text-white text-xs rounded-lg px-2 py-1.5">
+    </div>
+  </form>
+</div>
 
-    <!-- YEAR -->
-    <details id="y-{{ year.label }}" class="group">
-      <summary class="tree-summary tree-year">
-        <div class="flex items-center gap-3">
-          <span class="chevron text-slate-400">▶</span>
-          <span class="text-white font-bold text-lg">{{ year.label }}</span>
-        </div>
-        <div class="flex items-center flex-wrap justify-end gap-x-4 gap-y-1 text-sm">
-          <span class="text-slate-500 whitespace-nowrap">{{ year.count }} {{ t('trips_plural') }}</span>
-          <span class="text-white font-semibold whitespace-nowrap">{{ year.km | dist(1) }}</span>
-          {% if year.regen and not is_reev %}
-          <span class="text-green-400/90 font-medium whitespace-nowrap" title="{{ t('total_regen') }}">♻️ {{ year.regen | nice }} kWh</span>
-          {% endif %}
-          {% if year.cost %}
-          <span class="text-slate-300 whitespace-nowrap" title="{{ t('cost') }}">{{ year.cost | money }}</span>
-          {% endif %}
-          {% if year.avg_eff %}
-          <span class="eff-pill {{ eff_cls(year.avg_eff) }}">
-            {{ year.avg_eff | eff }}
-          </span>
-          {% endif %}
-          <button type="button" onclick="lmCollapseDetails(this,event)" class="collapse-btn">⊟</button>
-        </div>
-      </summary>
-
-      <div class="ml-4 mt-2 space-y-2">
-      {% for month in year.months.values() %}
-
-        <!-- MONTH -->
-        <details id="m-{{ month.label|replace(' ','_') }}" class="group/month">
-          <summary class="tree-summary tree-month">
-            <div class="flex items-center gap-3">
-              <span class="chevron text-slate-500 text-sm">▶</span>
-              <span class="text-slate-200 font-semibold">{{ month.label }}</span>
-            </div>
-            <div class="flex items-center flex-wrap justify-end gap-x-4 gap-y-1 text-xs">
-              <span class="text-slate-500 whitespace-nowrap">{{ month.count }} {{ t('trips_plural') }}</span>
-              <span class="text-slate-200 font-semibold whitespace-nowrap">{{ month.km | dist(1) }}</span>
-              {% if month.regen and not is_reev %}
-              <span class="text-green-400/90 font-medium whitespace-nowrap" title="{{ t('total_regen') }}">♻️ {{ month.regen | nice }} kWh</span>
-              {% endif %}
-              {% if month.cost %}
-              <span class="text-slate-300 whitespace-nowrap" title="{{ t('cost') }}">{{ month.cost | money }}</span>
-              {% endif %}
-              {% if month.avg_eff %}
-              <span class="eff-pill {{ eff_cls(month.avg_eff) }}">
-                {{ month.avg_eff | eff }}
-              </span>
-              {% endif %}
-              <button type="button" onclick="lmCollapseDetails(this,event)" class="collapse-btn">⊟</button>
-            </div>
-          </summary>
-
-          <div class="ml-4 mt-1.5 space-y-1.5">
-          {% for day in month.days.values() %}
-
-            <!-- DAY -->
-            <details id="d-{{ day.label|replace(' ','_') }}" class="group/day">
-              <summary class="tree-summary tree-day">
-                <div class="flex items-center gap-2">
-                  <span class="chevron text-slate-600 text-xs">▶</span>
-                  <span class="text-slate-300 text-sm font-medium">{{ day.label }}</span>
-                  <span class="text-slate-600 text-xs hidden sm:inline">— {{ day.count }} {{ t('trips_plural') if day.count > 1 else t('trip_singular') }}</span>
-                </div>
-                <div class="flex items-center flex-wrap justify-end gap-x-3 gap-y-1 text-xs">
-                  <span class="text-slate-400 font-medium whitespace-nowrap">{{ day.km | dist(1) }}</span>
-                  {% if day.regen and not is_reev %}
-                  <span class="text-green-400/90 font-medium whitespace-nowrap" title="{{ t('total_regen') }}">♻️ {{ day.regen | nice }} kWh</span>
-                  {% endif %}
-                  {% if day.cost %}
-                  <span class="text-slate-300 whitespace-nowrap" title="{{ t('cost') }}">{{ day.cost | money }}</span>
-                  {% endif %}
-                  {% if day.avg_eff %}
-                  <span class="eff-pill {{ eff_cls(day.avg_eff) }}">
-                    {{ day.avg_eff | eff }}
-                  </span>
-                  {% endif %}
-                </div>
-              </summary>
-
-              <!-- TRIPS inside the day -->
-              <div class="ml-4 mt-1 space-y-1">
-              {% for trip in day.trips %}
-              {% set used = (trip.start_soc or 0) - (trip.end_soc or 0) %}
-              <a href="trips/{{ trip.id }}"
-                 data-trip-id="{{ trip.id }}"
-                 class="trip-row">
-
-                <!-- Route thumbnail (browser-lazy, served as SVG); reconstructed trips have no GPS -->
-                {% if trip.reconstructed %}
-                <div class="trip-thumb flex items-center justify-center text-amber-400/70 text-lg"
-                     title="{{ t('trip_reconstructed_hint') }}">✨</div>
-                {% else %}
-                <img class="trip-thumb" loading="lazy" alt=""
-                     src="trips/{{ trip.id }}/route.svg">
-                {% endif %}
-
-                <!-- Time + duration -->
-                <div class="min-w-0 flex-1">
-                  <div class="text-white text-sm font-medium">
-                    {{ trip.started_at[11:16] if trip.started_at else '—' }}
-                    <span class="text-slate-500 font-normal text-xs ml-1">
-                      → {{ trip.ended_at[11:16] if trip.ended_at else '' }}
-                    </span>
-                    {% if trip.is_merged %}<span style="font-size:10px" class="text-yellow-400" title="{{ trip.merged_count }} {{ t('merge_segments') }}">🔗</span>{% endif %}
-                    {% if trip.reconstructed %}<span style="font-size:10px" class="text-amber-400/90 ml-1" title="{{ t('trip_reconstructed_hint') }}">✨ {{ t('trip_reconstructed') }}</span>{% endif %}
-                  </div>
-                  <div class="text-slate-500 text-xs">{{ fmt_dur(trip.duration_min) }}{% if trip.is_merged %} · {{ t('driving_only') }}{% endif %}</div>
-                </div>
-
-                <!-- SOC mini gauge -->
-                <div class="hidden sm:flex flex-col items-end gap-1 flex-shrink-0">
-                  <div class="soc-mini" title="{{ '%.0f'|format(trip.start_soc or 0) }}% → {{ '%.0f'|format(trip.end_soc or 0) }}%">
-                    <i class="soc-rem"  style="width:{{ trip.end_soc or 0 }}%"></i>
-                    <i class="soc-used" style="left:{{ trip.end_soc or 0 }}%;width:{{ used if used > 0 else 0 }}%"></i>
-                  </div>
-                  <div class="text-slate-500 text-[11px]">
-                    {{ "%.0f"|format(trip.start_soc or 0) }}→{{ "%.0f"|format(trip.end_soc or 0) }}%
-                  </div>
-                </div>
-
-                <!-- Stats -->
-                <div class="text-right flex-shrink-0" style="min-width:84px">
-                  <div class="text-white text-sm font-bold">{{ (trip.distance_km or 0) | dist(1) }}</div>
-                  {% if trip.efficiency_kwh_100km %}
-                  <span class="eff-pill {{ eff_cls(trip.efficiency_kwh_100km) }} mt-0.5">
-                    {{ trip.efficiency_kwh_100km | eff }}
-                  </span>
-                  {% endif %}
-                  {% if is_reev and research and trip.engine_ran %}
-                  {# REEV Phase C — flag an engine-on trip with its fuel consumption #}
-                  <span class="block mt-0.5 text-amber-400 text-[11px] font-semibold" title="{{ t('reev_engine_ran') }}">⛽ {% if trip.fuel_l_100km is not none %}{{ trip.fuel_l_100km | nice }} L/100km{% else %}{{ trip.fuel_used_l | nice }} L{% endif %}</span>
-                  {% endif %}
-                  {% if trip.ec_pending %}
-                  <span class="block mt-0.5 text-amber-400 text-[11px] font-medium" title="{{ t('ec_provisional') }}">⏳ {{ t('ec_provisional_short') }}</span>
-                  {% endif %}
-                </div>
-
-              </a>
-              {% if trip.is_merged %}
-              <div class="merge-sep" style="display:none;padding:0 0 4px 56px">
-                <button type="button"
-                        class="inline-flex items-center gap-1 rounded-md border border-slate-600 text-slate-300 px-2 py-0.5 text-[11px] font-medium hover:border-red-500 hover:text-red-400"
-                        hx-post="api/trips/unmerge?parent={{ trip.id }}" hx-swap="none">↩️ {{ t('unmerge_btn') }}</button>
-              </div>
-              {% endif %}
-              {% set nxt = day.trips[loop.index0 + 1] if not loop.last else none %}
-              {% if nxt and merge_pairs.get(trip.id) and merge_pairs[trip.id].a_id == nxt.id %}
-              {% set mp = merge_pairs[trip.id] %}
-              <div class="merge-connector" data-gap="{{ mp.gap }}" style="display:none;padding:0 0 2px 56px">
-                <button type="button"
-                        class="inline-flex items-center gap-1.5 rounded-md border border-yellow-500/50 bg-yellow-400/5 text-yellow-400 px-2.5 py-1 text-[11px] font-semibold hover:bg-yellow-400/15"
-                        hx-get="api/trips/merge-preview?a={{ mp.a_id }}&b={{ trip.id }}&gap={{ merge_gap_max }}"
-                        hx-target="#merge-modal-body" hx-swap="innerHTML"
-                        onclick="document.getElementById('merge-modal').style.display='flex'">
-                  🔗 {{ t('merge_join') }} <span class="font-normal opacity-70">· {{ t('merge_stop') }} {{ mp.gap }}′</span>
-                </button>
-              </div>
-              {% endif %}
-              {% endfor %}
-              </div>
-
-            </details>
-          {% endfor %}
-          </div>
-
-        </details>
-      {% endfor %}
-      </div>
-
-    </details>
+{% if cal_years and cal_years|length > 1 %}
+<!-- Year jump — only years with actual trips, so it never lists empty years -->
+<div class="flex items-center gap-2 flex-wrap mb-4">
+  {% for y in cal_years %}
+  <button type="button"
+          hx-get="api/trips/calendar?year={{ y }}&month={{ cal_month }}"
+          hx-target="#trips-calendar-month-wrap" hx-swap="innerHTML"
+          class="px-3 py-1.5 rounded-lg text-sm font-medium border border-slate-600 text-slate-300 hover:border-brand hover:text-white transition-colors">
+    {{ y }}
+  </button>
   {% endfor %}
-  </div>
-</section>
+</div>
+{% endif %}
+
+<!-- Merge candidates — dedicated view (see main.py trips_merge_candidates for why it's
+     no longer inline connectors between accordion rows) -->
+<div class="mb-4">
+  <button type="button"
+          hx-get="api/trips/merge-candidates" hx-trigger="click"
+          hx-target="#trips-calendar-month-wrap" hx-swap="innerHTML"
+          class="inline-flex items-center gap-2 rounded-lg border border-slate-600 bg-slate-800/60 px-3 py-2 text-sm font-medium text-slate-200 hover:bg-slate-700 hover:border-yellow-500/50 transition-all">
+    🔗 {{ t('merge_eligible') }}
+  </button>
+</div>
+
+<div class="card mb-6" id="trips-calendar-month-wrap"
+     hx-get="api/trips/calendar?year={{ cal_year }}&month={{ cal_month }}{% if cal_open_day %}&open_day={{ cal_open_day }}{% endif %}"
+     hx-trigger="load" hx-swap="innerHTML">
+  <div class="text-center text-slate-500 py-10">…</div>
+</div>
 
 {% else %}
 <div class="card text-center py-12 text-slate-500">
@@ -281,63 +151,23 @@
 {% endif %}
 
 <script>
-const LS_KEY = 'lm_trips_open';
 const HIGHLIGHT = {{ highlight }};
 
-// ── Restore open/closed state from localStorage ──────────────────────────────
-// Archive defaults to fully collapsed; the user's manual toggles persist.
-const saved = JSON.parse(localStorage.getItem(LS_KEY) || '{}');
-
-document.querySelectorAll('#trips-tree details').forEach(el => {
-  if (el.id in saved) {
-    el.open = saved[el.id];
-  } else {
-    // Default: year + month open, day closed
-    el.open = el.id.startsWith('y-') || el.id.startsWith('m-');
-  }
-});
-
-// Save state on every toggle. When a MONTH or YEAR is collapsed, also close the days inside it, so
-// re-opening it later shows them tidy (closed) instead of however they were last left open.
-document.querySelectorAll('#trips-tree details').forEach(el => {
-  el.addEventListener('toggle', () => {
-    const st = JSON.parse(localStorage.getItem(LS_KEY) || '{}');
-    st[el.id] = el.open;
-    if (!el.open && (el.id.startsWith('y-') || el.id.startsWith('m-'))) {
-      el.querySelectorAll('details[id^="d-"]').forEach(d => { d.open = false; st[d.id] = false; });
-    }
-    localStorage.setItem(LS_KEY, JSON.stringify(st));
-  });
-});
-
-// "Collapse all" closes only the DAY groups (months/years stay open) → one tap to tidy the list back
-// to a clean day-by-day overview, without losing the month structure or re-opening every trip.
-document.getElementById('collapse-all-trips')?.addEventListener('click', () => {
-  const st = JSON.parse(localStorage.getItem(LS_KEY) || '{}');
-  document.querySelectorAll('#trips-tree details[id^="d-"]').forEach(d => {
-    d.open = false;
-    st[d.id] = false;
-  });
-  localStorage.setItem(LS_KEY, JSON.stringify(st));
-});
-
-// ── Highlight and scroll to the selected trip ────────────────────────────────
+// A trip reached via ?highlight=<id> lands on the right month/day server-side (trips_page
+// resolves it and passes cal_open_day) — once that first HTMX load renders the day's rows,
+// find it, style it and scroll it into view. Same pattern as the Ricariche calendar.
 if (HIGHLIGHT) {
-  const row = document.querySelector(`#trips-tree [data-trip-id="${HIGHLIGHT}"]`);
-  if (row) {
-    // Open all ancestor <details> elements
-    let el = row.parentElement;
-    while (el) {
-      if (el.tagName === 'DETAILS') el.open = true;
-      el = el.parentElement;
+  document.body.addEventListener('htmx:afterSwap', function onSwap(e) {
+    if (!e.target || e.target.id !== 'trips-calendar-month-wrap') return;
+    const row = document.querySelector(`[data-trip-id="${HIGHLIGHT}"]`);
+    if (row) {
+      row.style.background = '#1a2e1a';
+      row.style.border     = '1px solid #22c55e55';
+      row.style.boxShadow  = 'inset 3px 0 0 #22c55e';
+      requestAnimationFrame(() => row.scrollIntoView({ behavior: 'smooth', block: 'center' }));
+      document.body.removeEventListener('htmx:afterSwap', onSwap);
     }
-    // Apply highlight style
-    row.style.background    = '#1a2e1a';
-    row.style.border        = '1px solid #22c55e55';
-    row.style.boxShadow     = 'inset 3px 0 0 #22c55e';
-    // Scroll into view after paint
-    requestAnimationFrame(() => row.scrollIntoView({ behavior: 'smooth', block: 'center' }));
-  }
+  });
 }
 </script>
 
@@ -347,53 +177,4 @@ if (HIGHLIGHT) {
   <div id="merge-modal-body" style="max-width:440px;width:100%"></div>
 </div>
 
-<script>
-// Merge mode: the 🔗 toggle reveals the in-tree connectors between joinable adjacent trips and opens
-// ONLY the days that actually contain something actionable (a connector visible at the current gap, or
-// an already-merged trip to split) — NOT the whole archive. The gap slider filters live; leaving merge
-// mode restores the exact view you had before.
-(function () {
-  const btn = document.getElementById('merge-toggle');
-  const bar = document.getElementById('merge-bar');
-  const slider = document.getElementById('merge-gap');
-  const out = document.getElementById('merge-gap-out');
-  let on = false, savedOpen = null;
-  function openAncestors(node) {            // open the day (+ its month/year) holding this element
-    let el = node.parentElement;
-    while (el && el.id !== 'trips-tree') {
-      if (el.tagName === 'DETAILS') el.open = true;
-      el = el.parentElement;
-    }
-  }
-  function apply() {
-    const g = slider ? +slider.value : {{ merge_gap_default }};
-    if (out) out.textContent = g;
-    document.querySelectorAll('.merge-connector').forEach(c => {
-      const show = on && (+c.dataset.gap) <= g;
-      c.style.display = show ? 'flex' : 'none';
-      if (show) openAncestors(c);
-    });
-    document.querySelectorAll('.merge-sep').forEach(s => {
-      s.style.display = on ? 'block' : 'none';
-      if (on) openAncestors(s);
-    });
-  }
-  btn && btn.addEventListener('click', () => {
-    on = !on;
-    btn.classList.toggle('border-yellow-500', on);
-    btn.classList.toggle('text-yellow-400', on);
-    btn.classList.toggle('bg-yellow-400/10', on);
-    if (bar) bar.style.display = on ? 'flex' : 'none';
-    if (on) {                               // remember the current view to restore on exit
-      savedOpen = {};
-      document.querySelectorAll('#trips-tree details').forEach(d => { savedOpen[d.id] = d.open; });
-    } else if (savedOpen) {                  // exit → put every group back exactly as it was
-      document.querySelectorAll('#trips-tree details').forEach(d => { d.open = !!savedOpen[d.id]; });
-      savedOpen = null;
-    }
-    apply();
-  });
-  slider && slider.addEventListener('input', apply);
-})();
-</script>
 {% endblock %}

--- a/web/templates/wallbox.html
+++ b/web/templates/wallbox.html
@@ -35,15 +35,30 @@
   <div class="text-sm text-slate-500">…</div>
 </div>
 
-<!-- Car-vs-wallbox: year/month/day session history; expand a session for its chart -->
-<div class="card">
-  <div class="flex items-center gap-2 mb-3">
-    <span class="text-lg">🔀</span>
-    <h2 class="font-semibold text-white">{{ t('wallbox_compare') }}</h2>
-  </div>
-  <div hx-get="api/wallbox/sessions" hx-trigger="load" hx-swap="innerHTML">
-    <div class="text-sm text-slate-500 py-2">…</div>
-  </div>
+<!-- Car-vs-wallbox: calendar Month view; expand a session for its chart -->
+<div class="mb-3 flex items-center gap-2">
+  <span class="text-lg">🔀</span>
+  <h2 class="font-semibold text-white">{{ t('wallbox_compare') }}</h2>
+</div>
+
+{% if cal_years and cal_years|length > 1 %}
+<!-- Year jump — only years with actual wallbox sessions -->
+<div class="flex items-center gap-2 flex-wrap mb-4">
+  {% for y in cal_years %}
+  <button type="button"
+          hx-get="api/wallbox/calendar?year={{ y }}&month={{ cal_month }}"
+          hx-target="#wallbox-calendar-month-wrap" hx-swap="innerHTML"
+          class="px-3 py-1.5 rounded-lg text-sm font-medium border border-slate-600 text-slate-300 hover:border-brand hover:text-white transition-colors">
+    {{ y }}
+  </button>
+  {% endfor %}
+</div>
+{% endif %}
+
+<div class="card" id="wallbox-calendar-month-wrap"
+     hx-get="api/wallbox/calendar?year={{ cal_year }}&month={{ cal_month }}"
+     hx-trigger="load" hx-swap="innerHTML">
+  <div class="text-center text-slate-500 py-10">…</div>
 </div>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION

EN:
Ricariche, Viaggi and Wallbox each showed their ENTIRE history as one big year/month/day accordion, rendered fully server-side on every page load and with no way to search. As the history grows this gets slower to load and harder to find anything in. All three now share the same pattern instead:

- A Month calendar (day totals only) with a day-drawer that lazily loads that ONE day's full cards/rows on click — a page load now ships a handful of numbers, not the whole history.
- Prev/month, jump-to-today, and year-jump pills (only for years that actually have data).
- Ricariche and Viaggi also get a search bar: free text (station name/note for charges, trip note for trips) plus advanced filters (charge type/cost/ kWh/date for charges; drive mode/distance/duration/date for trips). Clearing all filters falls back to the calendar server-side, not a client-side branch. Wallbox has no search bar — there's no free-text/ filterable field there beyond the date the calendar/year-pills already cover, so a search UI would have been decoration with nothing to search.
- The per-item card/row markup (charge card, trip row) is now a single reused partial instead of duplicated across the old tree, the day-drawer and search results.

Wallbox gets an extra win: the old accordion computed every session's AC-vs- DC comparison up front (each one a live Home Assistant history request) even though it only showed 30 sessions. That's now computed lazily, only for the day a user actually opens.

CRITICAL / trade-offs — please read before merging:
1. Trips' "🔗 Unisci" (merge) mode used to scan the whole rendered accordion for connectors between adjacent rows and reveal/hide them client-side. That has no equivalent once only one day is ever in the DOM, so it's now a DEDICATED view (its own button, replacing the calendar area) listing the actual mergeable pairs across all history — same gap slider, same preview/confirm modal, just a different layout. Please try it once before merging; this is the change most likely to warrant a second look.
2. Same feature: "Separa" (unmerge) on an already-merged trip was previously only shown once "merge mode" was toggled on (a soft guard against mis-clicks). It's now always visible on the row, with a confirm dialog added in its place.
3. get_charges_grouped, get_trips_grouped and the /api/wallbox/sessions endpoint (+ its _wallbox_sessions_grouped) are no longer called from any page — left in place with their existing tests rather than deleted, in case you'd rather keep the old data shape around. Say the word and I'll remove them together with their dedicated tests.
4. Trips search deliberately has NO efficiency (kWh/100km) range filter: in imperial units that figure is a RECIPROCAL (mi/kWh, higher = better), so a min/max filter would need its bounds swapped depending on the user's unit system. Scoped out rather than risk getting that silently wrong; distance/duration/date/drive-mode filters are unaffected and present. Distance filters ARE unit-aware (typed in the user's own km/mi, converted at the API boundary — same pattern as the maintenance-baseline odometer field).

IT:
Ricariche, Viaggi e Wallbox mostravano ciascuna l'INTERO storico come un unico grande accordion anno/mese/giorno, renderizzato per intero lato server a ogni caricamento pagina e senza alcun modo di cercare. Con lo storico che cresce, questo diventa sempre più lento da caricare e difficile da consultare. Ora tutte e tre condividono lo stesso schema:

- Un calendario Mese (solo totali per giorno) con un pannello del giorno che carica pigramente le card/righe complete di QUEL giorno al clic — un caricamento pagina ora trasporta una manciata di numeri, non l'intero storico.
- Mese precedente/successivo, salto a oggi, e pillole degli anni (solo per gli anni in cui esistono davvero dati).
- Ricariche e Viaggi hanno anche una barra di ricerca: testo libero (nome colonnina/nota per le ricariche, nota di viaggio per i viaggi) più filtri avanzati (tipo ricarica/costo/kWh/data per le ricariche; modalità di guida/distanza/durata/data per i viaggi). Svuotare tutti i filtri torna al calendario lato server, non con un ramo client-side. Il Wallbox non ha barra di ricerca — non c'è alcun campo testuale/filtrabile lì oltre alla data, già coperta da calendario e pillole anno, quindi una UI di ricerca sarebbe stata decorazione senza nulla da cercare.
- Il markup di ogni card/riga (card ricarica, riga viaggio) è ora un unico partial riutilizzato invece che duplicato tra il vecchio albero, il pannello del giorno e i risultati di ricerca.

Il Wallbox guadagna un vantaggio extra: il vecchio accordion calcolava il confronto AC/DC di OGNI sessione in anticipo (ciascuno una vera chiamata allo storico di Home Assistant) anche se ne mostrava solo 30. Ora viene calcolato pigramente, solo per il giorno che l'utente apre davvero.

CRITICO / compromessi — da leggere prima di mergiare:
1. La modalità "🔗 Unisci" dei Viaggi scandiva prima l'intero accordion renderizzato cercando connettori tra righe adiacenti, mostrandoli/ nascondendoli lato client. Non ha equivalente ora che in pagina c'è un solo giorno alla volta, quindi è diventata una vista DEDICATA (proprio pulsante, sostituisce l'area calendario) che elenca le coppie effettivamente unibili in tutto lo storico — stesso slider di sosta massima, stesso modale di anteprima/conferma, solo un layout diverso. Vi prego di provarla prima di mergiare; è la modifica che più merita un secondo sguardo.
2. Stessa funzionalità: "Separa" su un viaggio già unito prima compariva solo attivando la "modalità unisci" (una protezione leggera contro i clic accidentali). Ora è sempre visibile sulla riga, con una finestra di conferma al suo posto.
3. get_charges_grouped, get_trips_grouped e l'endpoint /api/wallbox/sessions (+ il suo _wallbox_sessions_grouped) non sono più chiamati da nessuna pagina — lasciati al loro posto con i test esistenti invece di cancellarli, nel caso vogliate tenere la vecchia struttura dati. Basta dirlo e li rimuovo insieme ai loro test dedicati.
4. La ricerca Viaggi NON ha volutamente un filtro per intervallo di efficienza (kWh/100km): in unità imperiali quel valore è un RECIPROCO (mi/kWh, più alto = meglio), quindi un filtro min/max dovrebbe scambiare i limiti a seconda del sistema di unità dell'utente. Escluso invece di rischiare di sbagliarlo silenziosamente; i filtri distanza/durata/data/ modalità di guida non sono toccati e sono presenti. I filtri di distanza SONO consapevoli dell'unità (digitati nei km/mi dell'utente, convertiti al confine dell'API — stesso schema del campo contachilometri nella baseline di manutenzione).