### PR TITLE
Add auto-generated notes for trips and charges with address, time, and temperature

### DIFF
--- a/poller/recorder.py
+++ b/poller/recorder.py
@@ -2,6 +2,7 @@
 Recorder: reacts to state machine events to persist trips, charges, and positions.
 """
 import logging
+import threading
 from typing import Optional
 
 from db import Database, _now_iso
@@ -173,7 +174,9 @@ class Recorder:
             return                                              # sub-1 km blip, not a trip
         if data.soc - prev_soc > 0.5:
             return                                              # SoC rose → a charge, not a pure drive
-        self._db.create_reconstructed_trip(self._vehicle_id, prev_soc, prev_odo, prev_ts, data)
+        trip_id = self._db.create_reconstructed_trip(self._vehicle_id, prev_soc, prev_odo, prev_ts, data)
+        if trip_id is not None:
+            self._auto_note_trip(trip_id)
 
     def _maybe_reconstruct_charge(self, data: VehicleData) -> None:
         """Catch a charge that was never seen live. While the car is asleep/offline to the cloud
@@ -195,7 +198,9 @@ class Recorder:
             return                                                 # live charge/trip owns this
         if data.soc - prev_soc < self._reconstruct_min_pct:
             return                                                 # drop or jitter, not a charge
-        self._db.create_reconstructed_charge(self._vehicle_id, prev_soc, prev_ts, data)
+        charge_id = self._db.create_reconstructed_charge(self._vehicle_id, prev_soc, prev_ts, data)
+        if charge_id is not None:
+            self._auto_note_charge(charge_id)
 
     # HA's leapmotor_trip ignores movements shorter than 0.5 km ("spostamento breve
     # ignorato"). Match it: finalize the trip, then drop it if it was a short hop.
@@ -207,6 +212,8 @@ class Recorder:
             self._db.delete_trip(self._active_trip_id)
             log.info("Trip #%d discarded — short hop %.2f km (< %.1f km)",
                      self._active_trip_id, distance_km, self._MIN_TRIP_KM)
+            return
+        self._auto_note_trip(self._active_trip_id)
 
     def mark_offline(self) -> None:
         events = self._sm.mark_offline()
@@ -233,6 +240,53 @@ class Recorder:
         except Exception as e:  # noqa: BLE001
             log.debug("wallbox energy read failed: %s", e)
             return None
+
+    @staticmethod
+    def _web_db_reader():
+        """web/db_reader.py — same sys.path trick as _read_wallbox_energy's ha_client
+        import. Reused here since the auto-note generation (reverse-geocoding + station
+        lookup) lives there, and pulls in only stdlib-http modules (web/geocode.py,
+        web/charger_locator.py) already covered by web's own requirements — no new pip
+        dependency for the poller."""
+        import sys
+        import pathlib
+        web = str(pathlib.Path(__file__).resolve().parent.parent / "web")
+        if web not in sys.path:
+            sys.path.insert(0, web)
+        import db_reader
+        return db_reader
+
+    def _auto_note_trip(self, trip_id: int) -> None:
+        """Kick the address/time/temperature auto-note for a brand-new trip, off-thread —
+        reverse-geocoding can take a few seconds and must never delay the next poll cycle.
+        only_if_note_empty=True is the safety net: never clobbers a note the user
+        somehow already typed in the few seconds between the trip closing and this
+        thread running (the 🧭 button is the only thing allowed to overwrite a note, and
+        only after the user confirms — see web/main.py trip_generate_auto_note)."""
+        threading.Thread(target=self._auto_note_trip_body, args=(trip_id,), daemon=True).start()
+
+    def _auto_note_trip_body(self, trip_id: int) -> None:
+        try:
+            db_reader = self._web_db_reader()
+            provider = db_reader.get_setting("geocoder_provider", "")
+            key = db_reader.get_secret("geocoder_key", "") or None
+            db_reader.generate_trip_auto_note(trip_id, provider, key, only_if_note_empty=True)
+        except Exception as e:  # noqa: BLE001 — best-effort, must never take the poller down
+            log.debug("trip #%d auto-note failed: %s", trip_id, e)
+
+    def _auto_note_charge(self, charge_id: int) -> None:
+        """Same as _auto_note_trip, for a brand-new charge (station address + telemetry
+        temperatures instead of reverse-geocoded endpoints + Open-Meteo)."""
+        threading.Thread(target=self._auto_note_charge_body, args=(charge_id,), daemon=True).start()
+
+    def _auto_note_charge_body(self, charge_id: int) -> None:
+        try:
+            db_reader = self._web_db_reader()
+            provider = db_reader.get_setting("geocoder_provider", "")
+            key = db_reader.get_secret("geocoder_key", "") or None
+            db_reader.generate_charge_auto_note(charge_id, provider, key, only_if_note_empty=True)
+        except Exception as e:  # noqa: BLE001 — best-effort, must never take the poller down
+            log.debug("charge #%d auto-note failed: %s", charge_id, e)
 
     def _handle_event(self, event: StateEvent, data: Optional[VehicleData]) -> None:
         frm, to = event.from_state, event.to_state
@@ -288,5 +342,6 @@ class Recorder:
                 self._db.finalize_charge(
                     self._active_charge_id, data, max_power_kw=self._max_charge_kw,
                 )
+                self._auto_note_charge(self._active_charge_id)
             self._active_charge_id = None
             self._max_charge_kw = 0.0

--- a/tests/test_auto_note.py
+++ b/tests/test_auto_note.py
@@ -1,0 +1,332 @@
+"""The 🧭 auto-generated address/time/temperature summary, for both trips and charges.
+Simplified design: no separate read-only field — the summary is written STRAIGHT INTO
+the note (the one note field). For a brand-new trip/charge the poller populates it
+automatically (only_if_note_empty=True — see tests/test_auto_note_recorder.py); the 🧭
+button on an existing record always overwrites, but the UI warns first with a confirm
+popup when there's manual text to lose (trip_detail.html / charge_card.html's conditional
+hx-confirm). Live network calls (reverse-geocoding has no caching and Nominatim's usage
+policy forbids bulk lookups) are safe here because each call is for exactly one NEW
+trip/charge, never a historical backfill sweep.
+"""
+import asyncio
+
+import pytest
+
+import db as D
+import db_reader
+
+
+def _hhmm(iso: str) -> str:
+    """Expected local HH:MM for a UTC timestamp — the note formats in local time
+    (db_reader._local_dt), so a literal UTC hour would be wrong under any non-UTC tz."""
+    return db_reader._local_dt(iso).strftime("%H:%M")
+
+
+class _Req:
+    """The endpoints only ever pass this to the template renderer, which is faked below."""
+
+
+class _FakeTemplates:
+    def __init__(self):
+        self.rendered = []
+
+    def TemplateResponse(self, request, name, ctx):   # noqa: N802 — mirrors Starlette's name
+        self.rendered.append((name, ctx))
+        return ctx
+
+
+@pytest.fixture
+def pdb(tmp_path, monkeypatch):
+    path = str(tmp_path / "t.db")
+    database = D.Database(path)
+    monkeypatch.setattr(db_reader, "DB_PATH", path)
+    return database
+
+
+# ── get_position_near ──────────────────────────────────────────────────────────
+
+def _add_position(pdb, ts, outside_temp=None, battery_min_temp=None):
+    pdb._conn.execute(
+        "INSERT INTO positions (vehicle_id, recorded_at, outside_temp, battery_min_temp) "
+        "VALUES (1,?,?,?)", (ts, outside_temp, battery_min_temp))
+    pdb._conn.commit()
+
+
+def test_get_position_near_picks_closest_within_tolerance(pdb):
+    _add_position(pdb, "2026-07-04T09:50:00+00:00", outside_temp=18)
+    _add_position(pdb, "2026-07-04T10:05:00+00:00", outside_temp=20, battery_min_temp=24)
+    _add_position(pdb, "2026-07-04T10:40:00+00:00", outside_temp=30)
+
+    pos = db_reader.get_position_near("2026-07-04T10:00:00+00:00")
+    assert pos["outside_temp"] == 20
+    assert pos["battery_min_temp"] == 24
+
+
+def test_get_position_near_none_outside_tolerance(pdb):
+    _add_position(pdb, "2026-07-04T09:00:00+00:00", outside_temp=18)
+    assert db_reader.get_position_near("2026-07-04T10:00:00+00:00", tolerance_min=20) is None
+
+
+def test_get_position_near_none_when_ts_missing_or_unparseable(pdb):
+    assert db_reader.get_position_near(None) is None
+    assert db_reader.get_position_near("not-a-date") is None
+
+
+# ── generate_trip_auto_note ─────────────────────────────────────────────────────
+
+def _add_trip(pdb, started, ended, start_lat=45.0, start_lon=9.0, end_lat=45.1, end_lon=9.1,
+              outside_temp_start_c=None, outside_temp_end_c=None, note=None):
+    pdb._conn.execute(
+        "INSERT INTO trips (vehicle_id, started_at, ended_at, start_lat, start_lon, end_lat, end_lon,"
+        " outside_temp_start_c, outside_temp_end_c, note) VALUES (1,?,?,?,?,?,?,?,?,?)",
+        (started, ended, start_lat, start_lon, end_lat, end_lon,
+         outside_temp_start_c, outside_temp_end_c, note))
+    pdb._conn.commit()
+    return db_reader._get().execute("SELECT MAX(id) AS id FROM trips").fetchone()["id"]
+
+
+def test_generate_trip_auto_note_builds_and_persists_into_note(pdb, monkeypatch):
+    import geocode
+    tid = _add_trip(pdb, "2026-07-04T10:00:00+00:00", "2026-07-04T10:30:00+00:00",
+                    outside_temp_start_c=18.0, outside_temp_end_c=21.0)
+    addrs = {(45.0, 9.0): "Via Roma 1, Milano", (45.1, 9.1): "Via Torino 2, Milano"}
+    monkeypatch.setattr(geocode, "reverse_geocode",
+                        lambda lat, lon, provider, api_key: addrs[(lat, lon)])
+
+    text = db_reader.generate_trip_auto_note(tid)
+
+    assert "Via Roma 1, Milano" in text
+    assert "Via Torino 2, Milano" in text
+    assert _hhmm("2026-07-04T10:00:00+00:00") in text and _hhmm("2026-07-04T10:30:00+00:00") in text
+    assert "18" in text and "21" in text
+    row = db_reader._get().execute("SELECT note FROM trips WHERE id=?", (tid,)).fetchone()
+    assert row["note"] == text
+
+
+def test_generate_trip_auto_note_missing_trip_returns_none(pdb):
+    assert db_reader.generate_trip_auto_note(999) is None
+
+
+def test_generate_trip_auto_note_survives_a_geocoding_failure(pdb, monkeypatch):
+    """One endpoint's network hiccup must not blank the other endpoint's time+temperature —
+    reverse_geocode's own urllib call can raise (timeout, DNS blip), not just return None."""
+    import geocode
+    tid = _add_trip(pdb, "2026-07-04T10:00:00+00:00", "2026-07-04T10:30:00+00:00",
+                    outside_temp_start_c=18.0, outside_temp_end_c=21.0)
+    monkeypatch.setattr(geocode, "reverse_geocode",
+                        lambda lat, lon, provider, api_key: (_ for _ in ()).throw(TimeoutError()))
+
+    text = db_reader.generate_trip_auto_note(tid)
+
+    assert _hhmm("2026-07-04T10:00:00+00:00") in text and _hhmm("2026-07-04T10:30:00+00:00") in text
+    assert "18" in text and "21" in text
+
+
+def test_generate_trip_auto_note_regenerating_overwrites(pdb, monkeypatch):
+    import geocode
+    tid = _add_trip(pdb, "2026-07-04T10:00:00+00:00", "2026-07-04T10:30:00+00:00")
+    monkeypatch.setattr(geocode, "reverse_geocode", lambda lat, lon, provider, api_key: "First")
+    first = db_reader.generate_trip_auto_note(tid)
+    monkeypatch.setattr(geocode, "reverse_geocode", lambda lat, lon, provider, api_key: "Second")
+    second = db_reader.generate_trip_auto_note(tid)
+
+    assert "First" in first and "Second" in second
+    row = db_reader._get().execute("SELECT note FROM trips WHERE id=?", (tid,)).fetchone()
+    assert row["note"] == second
+
+
+def test_generate_trip_auto_note_default_overwrites_existing_note(pdb, monkeypatch):
+    """The manual 🧭 button always overwrites — the UI is what confirms with the user
+    first, not the generator (which stays a dumb, always-overwrite primitive)."""
+    import geocode
+    tid = _add_trip(pdb, "2026-07-04T10:00:00+00:00", "2026-07-04T10:30:00+00:00",
+                    note="Traffico intenso in autostrada")
+    monkeypatch.setattr(geocode, "reverse_geocode", lambda lat, lon, provider, api_key: "New address")
+
+    text = db_reader.generate_trip_auto_note(tid)
+
+    assert "Traffico intenso" not in text
+    row = db_reader._get().execute("SELECT note FROM trips WHERE id=?", (tid,)).fetchone()
+    assert row["note"] == text
+
+
+def test_generate_trip_auto_note_only_if_empty_skips_existing_note(pdb, monkeypatch):
+    """The automatic at-trip-close path (poller) must never clobber a note that already
+    has manual text in it."""
+    import geocode
+    tid = _add_trip(pdb, "2026-07-04T10:00:00+00:00", "2026-07-04T10:30:00+00:00",
+                    note="Traffico intenso in autostrada")
+    monkeypatch.setattr(geocode, "reverse_geocode", lambda lat, lon, provider, api_key: "New address")
+
+    result = db_reader.generate_trip_auto_note(tid, only_if_note_empty=True)
+
+    assert result == "Traffico intenso in autostrada"
+    row = db_reader._get().execute("SELECT note FROM trips WHERE id=?", (tid,)).fetchone()
+    assert row["note"] == "Traffico intenso in autostrada"
+
+
+def test_generate_trip_auto_note_only_if_empty_fills_a_blank_note(pdb, monkeypatch):
+    import geocode
+    tid = _add_trip(pdb, "2026-07-04T10:00:00+00:00", "2026-07-04T10:30:00+00:00")
+    monkeypatch.setattr(geocode, "reverse_geocode", lambda lat, lon, provider, api_key: "Fresh address")
+
+    text = db_reader.generate_trip_auto_note(tid, only_if_note_empty=True)
+
+    assert "Fresh address" in text
+    row = db_reader._get().execute("SELECT note FROM trips WHERE id=?", (tid,)).fetchone()
+    assert row["note"] == text
+
+
+# ── generate_charge_auto_note ────────────────────────────────────────────────────
+
+def _add_charge(pdb, started, ended, lat=45.0, lon=9.0, location_type="FAST", location_name=None,
+                note=None):
+    pdb._conn.execute(
+        "INSERT INTO charges (vehicle_id, started_at, ended_at, latitude, longitude,"
+        " location_type, location_name, note) VALUES (1,?,?,?,?,?,?,?)",
+        (started, ended, lat, lon, location_type, location_name, note))
+    pdb._conn.commit()
+    return db_reader._get().execute("SELECT MAX(id) AS id FROM charges").fetchone()["id"]
+
+
+def test_generate_charge_auto_note_builds_and_persists_into_note(pdb, monkeypatch):
+    import charger_locator
+    cid = _add_charge(pdb, "2026-07-04T12:00:00+00:00", "2026-07-04T12:30:00+00:00",
+                      location_name="Ionity Binasco")
+    _add_position(pdb, "2026-07-04T12:00:00+00:00", outside_temp=19, battery_min_temp=24)
+    _add_position(pdb, "2026-07-04T12:30:00+00:00", outside_temp=20, battery_min_temp=26)
+    monkeypatch.setattr(charger_locator, "find_station_candidates",
+                        lambda la, lo: ([{"name": "Ionity Binasco", "address": "Via Milano 1"}], True))
+
+    text = db_reader.generate_charge_auto_note(cid)
+
+    assert "Via Milano 1" in text
+    assert _hhmm("2026-07-04T12:00:00+00:00") in text and _hhmm("2026-07-04T12:30:00+00:00") in text
+    assert "24" in text and "26" in text
+    row = db_reader._get().execute("SELECT note FROM charges WHERE id=?", (cid,)).fetchone()
+    assert row["note"] == text
+
+
+def test_generate_charge_auto_note_skips_address_lookup_for_home(pdb, monkeypatch):
+    import charger_locator
+    called = []
+    monkeypatch.setattr(charger_locator, "find_station_candidates",
+                        lambda la, lo: called.append(1) or ([], True))
+    cid = _add_charge(pdb, "2026-07-04T12:00:00+00:00", "2026-07-04T12:30:00+00:00",
+                      location_type="HOME")
+
+    db_reader.generate_charge_auto_note(cid)
+
+    assert not called   # HOME never triggers a station lookup — no site to address
+
+
+def test_generate_charge_auto_note_missing_charge_returns_none(pdb):
+    assert db_reader.generate_charge_auto_note(999) is None
+
+
+def test_generate_charge_auto_note_blank_temps_when_no_telemetry(pdb, monkeypatch):
+    """Some cars don't report outside_temp at all (known sensor gap) — the note still
+    carries the address+time, just without the missing figure."""
+    import charger_locator
+    monkeypatch.setattr(charger_locator, "find_station_candidates",
+                        lambda la, lo: ([{"name": None, "address": "Via Milano 1"}], True))
+    cid = _add_charge(pdb, "2026-07-04T12:00:00+00:00", "2026-07-04T12:30:00+00:00")
+
+    text = db_reader.generate_charge_auto_note(cid)
+
+    assert "Via Milano 1" in text
+    assert _hhmm("2026-07-04T12:00:00+00:00") in text and _hhmm("2026-07-04T12:30:00+00:00") in text
+
+
+def test_generate_charge_auto_note_borrows_address_from_a_sibling_option(pdb, monkeypatch):
+    """Real-world bug: the charge's own name-matched option (e.g. the OSM node) can have
+    no street address even though a DIFFERENT source at the SAME physical site (e.g. the
+    OCM/PUN entry a few metres away, under a different name) does. charger_locator keeps
+    them as separate options on purpose (lets the manual relocate button offer a choice),
+    so the address must be borrowed here rather than silently left blank."""
+    import charger_locator
+    monkeypatch.setattr(charger_locator, "find_station_candidates", lambda la, lo: ([
+        {"name": "IONITY Versilia Ovest", "address": None, "dist_m": 9},
+        {"name": "Ionity AdS Versilia Ovest", "address": "A12 km 131, Pietrasanta", "dist_m": 16},
+    ], True))
+    cid = _add_charge(pdb, "2026-07-04T12:00:00+00:00", "2026-07-04T12:30:00+00:00",
+                      location_name="IONITY Versilia Ovest")
+
+    text = db_reader.generate_charge_auto_note(cid)
+
+    assert "A12 km 131, Pietrasanta" in text
+
+
+def test_generate_charge_auto_note_only_if_empty_skips_existing_note(pdb, monkeypatch):
+    import charger_locator
+    monkeypatch.setattr(charger_locator, "find_station_candidates",
+                        lambda la, lo: ([{"name": None, "address": "Via Milano 1"}], True))
+    cid = _add_charge(pdb, "2026-07-04T12:00:00+00:00", "2026-07-04T12:30:00+00:00",
+                      note="Colonnina lenta ma comoda")
+
+    result = db_reader.generate_charge_auto_note(cid, only_if_note_empty=True)
+
+    assert result == "Colonnina lenta ma comoda"
+    row = db_reader._get().execute("SELECT note FROM charges WHERE id=?", (cid,)).fetchone()
+    assert row["note"] == "Colonnina lenta ma comoda"
+
+
+# ── main.py endpoints ────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def main_env(pdb, monkeypatch):
+    pytest.importorskip("fastapi", reason="web.main needs fastapi (absent in the minimal CI test env)")
+    import main
+    monkeypatch.setattr(db_reader, "get_language", lambda: "en")
+    fake = _FakeTemplates()
+    monkeypatch.setattr(main, "templates", fake)
+    return main, fake
+
+
+def test_trip_auto_note_endpoint_writes_note_and_renders_textarea(main_env, monkeypatch):
+    import geocode
+    main, fake = main_env
+    conn = db_reader._conn_rw()
+    conn.execute(
+        "INSERT INTO trips (vehicle_id, started_at, ended_at, start_lat, start_lon, end_lat, end_lon)"
+        " VALUES (1,'2026-07-04T10:00:00+00:00','2026-07-04T10:30:00+00:00',45.0,9.0,45.1,9.1)")
+    conn.commit()
+    tid = conn.execute("SELECT MAX(id) AS id FROM trips").fetchone()["id"]
+    monkeypatch.setattr(geocode, "reverse_geocode", lambda lat, lon, provider, api_key: "Some Address")
+
+    asyncio.run(main.trip_generate_auto_note(_Req(), tid))
+
+    name, ctx = fake.rendered[-1]
+    assert name == "partials/trip_note_textarea.html"
+    assert "Some Address" in ctx["trip"]["note"]
+    row = db_reader._get().execute("SELECT note FROM trips WHERE id=?", (tid,)).fetchone()
+    assert row["note"] == ctx["trip"]["note"]
+
+
+def test_charge_auto_note_endpoint_writes_note_and_renders_textarea(main_env, monkeypatch):
+    import charger_locator
+    main, fake = main_env
+    conn = db_reader._conn_rw()
+    conn.execute(
+        "INSERT INTO charges (vehicle_id, started_at, ended_at, latitude, longitude, location_type)"
+        " VALUES (1,'2026-07-04T12:00:00+00:00','2026-07-04T12:30:00+00:00',45.0,9.0,'FAST')")
+    conn.commit()
+    cid = conn.execute("SELECT MAX(id) AS id FROM charges").fetchone()["id"]
+    monkeypatch.setattr(charger_locator, "find_station_candidates",
+                        lambda la, lo: ([{"name": None, "address": "Via Milano 1"}], True))
+
+    asyncio.run(main.charge_generate_auto_note(_Req(), cid))
+
+    name, ctx = fake.rendered[-1]
+    assert name == "partials/charge_note_textarea.html"
+    assert "Via Milano 1" in ctx["c"]["note"]
+
+
+# ── i18n coverage ────────────────────────────────────────────────────────────────
+
+def test_auto_note_strings_present_in_every_locale():
+    import i18n
+    for lang in ("en", "it", "de", "fr", "pl", "pt-PT"):
+        t = i18n.get_t(lang)
+        for key in ("auto_note_generate_btn", "auto_note_overwrite_confirm"):
+            assert t(key) != key, f"{lang} is missing {key}"

--- a/tests/test_auto_note_recorder.py
+++ b/tests/test_auto_note_recorder.py
@@ -1,0 +1,140 @@
+"""Automatic 🧭 note generation for a BRAND-NEW trip/charge — the poller kicks it off the
+moment the record closes (live DRIVING→PARKED / CHARGING→PARKED, or a reconstructed trip/
+charge from an offline gap), never a historical sweep. These tests drive the real Recorder
+through real state transitions and only stub out _auto_note_trip/_auto_note_charge
+themselves (network + threading — see test_auto_note.py for what those actually build).
+"""
+import types
+
+import db as D
+import recorder as R
+from client import VehicleData
+from state_machine import State, StateEvent
+
+
+def _vd(soc=50.0, lat=45.0, lon=9.0, odometer_km=1000.0):
+    return VehicleData(
+        vin="TESTVIN", timestamp_ms=0, soc=soc, range_km=300, odometer_km=odometer_km,
+        speed_kmh=0.0, gear="P", vehicle_state="parked",
+        charging_status=0, charge_power_kw=0.0, latitude=lat, longitude=lon,
+        outside_temp=None, inside_temp=20.0, climate_target_temp=21.0, battery_min_temp=15.0,
+        is_locked=True, climate_on=False, climate_cooling=False, climate_heating=False,
+        climate_defrost=False, trunk_open=False, windows_open=False, sunshade_open=False,
+        any_door_open=False, plug_connected=False, remaining_charge_min=0,
+        charge_voltage_v=0.0, charge_current_a=0.0,
+    )
+
+
+def _rec(db):
+    rec = R.Recorder(db, vehicle_id=1)
+    rec._read_wallbox_energy = lambda: None   # no HA wallbox in this test env
+    return rec
+
+
+# ── live trip close ──────────────────────────────────────────────────────────────
+
+def test_live_trip_close_triggers_auto_note(tmp_path):
+    db = D.Database(str(tmp_path / "t.db"))
+    rec = _rec(db)
+    calls = []
+    rec._auto_note_trip = lambda tid: calls.append(tid)
+
+    rec._handle_event(StateEvent(State.PARKED_ACTIVE, State.DRIVING, _vd()), _vd())
+    trip_id = rec._active_trip_id
+    end = _vd(odometer_km=1010.0)   # 10 km — clears the 0.5 km short-hop floor
+    rec._handle_event(StateEvent(State.DRIVING, State.PARKED_ACTIVE, end), end)
+
+    assert calls == [trip_id]
+
+
+def test_short_hop_trip_is_discarded_without_auto_note(tmp_path):
+    """A trip under the 0.5 km floor gets deleted outright — auto-noting a row that no
+    longer exists would just be a wasted network call for nothing."""
+    db = D.Database(str(tmp_path / "t.db"))
+    rec = _rec(db)
+    calls = []
+    rec._auto_note_trip = lambda tid: calls.append(tid)
+
+    rec._handle_event(StateEvent(State.PARKED_ACTIVE, State.DRIVING, _vd()), _vd())
+    end = _vd(odometer_km=1000.1)   # 0.1 km — below the short-hop floor
+    rec._handle_event(StateEvent(State.DRIVING, State.PARKED_ACTIVE, end), end)
+
+    assert calls == []
+
+
+# ── live charge close ────────────────────────────────────────────────────────────
+
+def test_live_charge_close_triggers_auto_note(tmp_path):
+    db = D.Database(str(tmp_path / "t.db"))
+    rec = _rec(db)
+    calls = []
+    rec._auto_note_charge = lambda cid: calls.append(cid)
+
+    rec._handle_event(StateEvent(State.PARKED_ACTIVE, State.CHARGING, _vd()), _vd())
+    charge_id = rec._active_charge_id
+    end = _vd(soc=80.0)
+    rec._handle_event(StateEvent(State.CHARGING, State.PARKED_ACTIVE, end), end)
+
+    assert calls == [charge_id]
+
+
+# ── reconstructed charge (offline SoC jump, #29) ─────────────────────────────────
+
+def test_reconstructed_charge_triggers_auto_note(tmp_path):
+    db = D.Database(str(tmp_path / "t.db"))
+    db.set_battery_capacity(50.0)
+    db.ensure_vehicle("TESTVIN", "B10")
+    rec = _rec(db)
+    calls = []
+    rec._auto_note_charge = lambda cid: calls.append(cid)
+    rec._sm.state = State.PARKED_ACTIVE
+    rec._last_soc, rec._last_soc_ts = 60.0, "2026-06-09T10:00:00+00:00"
+
+    rec._maybe_reconstruct_charge(_vd(soc=70.0))
+
+    assert len(calls) == 1
+    row = db._conn.execute("SELECT id FROM charges WHERE id=?", (calls[0],)).fetchone()
+    assert row is not None
+
+
+# ── reconstructed trip (offline odometer jump, #118) ─────────────────────────────
+
+def test_reconstructed_trip_triggers_auto_note(tmp_path):
+    db = D.Database(str(tmp_path / "t.db"))
+    db.ensure_vehicle("TESTVIN", "B10")
+    rec = _rec(db)
+    calls = []
+    rec._auto_note_trip = lambda tid: calls.append(tid)
+    rec._sm.state = State.PARKED_ACTIVE
+    rec._last_odometer = 1000.0
+    rec._last_soc, rec._last_soc_ts = 60.0, "2026-06-09T10:00:00+00:00"
+
+    rec._maybe_reconstruct_trip(_vd(soc=60.0, odometer_km=1010.0))   # +10 km, flat SoC → a drive
+
+    assert len(calls) == 1
+    row = db._conn.execute("SELECT id FROM trips WHERE id=?", (calls[0],)).fetchone()
+    assert row is not None
+
+
+# ── the real body: only_if_note_empty guards a note already present ──────────────
+
+def test_auto_note_trip_body_never_overwrites_a_note_typed_in_the_meantime(tmp_path, monkeypatch):
+    """Belt-and-suspenders: even though this runs moments after trip-close, prove the
+    only_if_note_empty guard actually reaches db_reader.generate_trip_auto_note."""
+    import db_reader
+    import geocode
+    monkeypatch.setattr(db_reader, "DB_PATH", str(tmp_path / "t.db"))
+    pdb = D.Database(str(tmp_path / "t.db"))
+    pdb._conn.execute(
+        "INSERT INTO trips (vehicle_id, started_at, ended_at, start_lat, start_lon, note)"
+        " VALUES (1,'2026-07-04T10:00:00+00:00','2026-07-04T10:30:00+00:00',45.0,9.0,"
+        "'nota scritta a mano')")
+    pdb._conn.commit()
+    tid = pdb._conn.execute("SELECT MAX(id) AS id FROM trips").fetchone()[0]
+    monkeypatch.setattr(geocode, "reverse_geocode", lambda lat, lon, provider, api_key: "Some address")
+
+    rec = R.Recorder(pdb, vehicle_id=1)
+    rec._auto_note_trip_body(tid)
+
+    row = pdb._conn.execute("SELECT note FROM trips WHERE id=?", (tid,)).fetchone()
+    assert row[0] == "nota scritta a mano"

--- a/web/db_reader.py
+++ b/web/db_reader.py
@@ -3452,6 +3452,175 @@ def _iso_to_utc(x):
         return x
 
 
+def get_position_near(ts: "str | None", tolerance_min: int = 20) -> "dict | None":
+    """The single positions row closest to timestamp `ts` (within tolerance_min minutes
+    either side) — for reading outside_temp/battery_min_temp at an arbitrary INSTANT (a
+    trip's or charge's own start/end), which nothing needed before: every existing
+    telemetry query is either "latest" (status cards) or a min/max aggregate over a whole
+    charging window (_charge_temp_odo), never "nearest to one point in time." None when
+    `ts` is missing/unparseable, or nothing falls within the tolerance window (e.g. the
+    sample was already pruned by the positions_retention_days setting)."""
+    utc = _iso_to_utc(ts)
+    if not utc:
+        return None
+    target = _trip_epoch(utc)
+    if target is None:
+        return None
+    try:
+        center = datetime.fromisoformat(utc)
+    except Exception:
+        return None
+    lo = (center - timedelta(minutes=tolerance_min)).isoformat()
+    hi = (center + timedelta(minutes=tolerance_min)).isoformat()
+    rows = _get().execute(
+        "SELECT * FROM positions WHERE vehicle_id = COALESCE(?, vehicle_id) "
+        "AND recorded_at >= ? AND recorded_at <= ? ORDER BY recorded_at",
+        (_current_vehicle_id(), lo, hi)).fetchall()
+    if not rows:
+        return None
+    best = min(rows, key=lambda r: abs((_trip_epoch(r["recorded_at"]) or 0) - target))
+    return dict(best)
+
+
+def generate_trip_auto_note(trip_id: int, provider: str = "", api_key: "str | None" = None,
+                             only_if_note_empty: bool = False) -> "str | None":
+    """Builds the start/end address+time+temperature summary and writes it straight into
+    the trip's `note` field (the ONE note field — no separate read-only line to keep in
+    sync). Reverse-geocoding is a live network call (web/geocode.py, no caching, and
+    Nominatim's usage policy forbids bulk lookups) — safe for the 🧭 button (one trip) and
+    for the automatic call at trip-close (poller/recorder.py, one NEW trip at a time), but
+    never a historical backfill sweep. `only_if_note_empty` is the automatic-at-close
+    guard: a manual note the user already typed is never clobbered by this running just
+    after; the manual button always overwrites (the UI confirms with the user first when
+    there's something to lose — see trip_detail.html's hx-confirm). Temperature reuses the
+    trip's own outside_temp_start_c/end_c (Open-Meteo, already collected by
+    elevation_enrich) — None when that enrichment hasn't run yet (may still be the case
+    right at trip-close; regenerating later via the button picks it up once it has)."""
+    import geocode
+    import units
+    row = _get().execute("SELECT * FROM trips WHERE id=? AND vehicle_id = COALESCE(?, vehicle_id)",
+                         (trip_id, _current_vehicle_id())).fetchone()
+    if not row:
+        return None
+    row = dict(row)
+    if only_if_note_empty and (row.get("note") or "").strip():
+        return row.get("note")
+
+    def _addr(lat, lon):
+        # geocode.reverse_geocode's own keyed-provider path swallows failures and falls back to
+        # Nominatim, but that final call (urllib underneath) can still raise on a timeout/DNS
+        # blip — one endpoint's network hiccup must not blank the other endpoint's time+temp.
+        if lat is None or lon is None:
+            return None
+        try:
+            return geocode.reverse_geocode(lat, lon, provider, api_key)
+        except Exception:  # noqa: BLE001
+            return None
+
+    start_addr = _addr(row.get("start_lat"), row.get("start_lon"))
+    end_addr = _addr(row.get("end_lat"), row.get("end_lon"))
+    start_dt = _local_dt(row.get("started_at"))
+    end_dt = _local_dt(row.get("ended_at"))
+
+    def _line(marker: str, addr, dt, temp_c) -> "str | None":
+        if not dt:
+            return None
+        bits = ([addr] if addr else []) + [dt.strftime("%H:%M")]
+        if temp_c is not None:
+            bits.append(f"🌡️ {units.temp(temp_c)}")
+        text = " · ".join(bits)
+        return f"{marker} {text}" if marker else text
+
+    lines = [_line("", start_addr, start_dt, row.get("outside_temp_start_c")),
+             _line("→", end_addr, end_dt, row.get("outside_temp_end_c"))]
+    text = (" ".join(l for l in lines if l) or None)
+    if text:
+        text = text.strip()[:1000]
+    db = _conn_rw()
+    db.execute("UPDATE trips SET note=? WHERE id=?", (text, trip_id))
+    db.commit()
+    return text
+
+
+def generate_charge_auto_note(charge_id: int, provider: str = "", api_key: "str | None" = None,
+                               only_if_note_empty: bool = False) -> "str | None":
+    """Builds the station-address+start/end time+temperature summary and writes it
+    straight into the charge's `note` field (the ONE note field — no separate read-only
+    line to keep in sync). The address reuses find_station_candidates — the SAME OSM/OCM
+    lookup the 📍 label/🔗 link already run — matched to the charge's own resolved name
+    when possible; skipped for HOME charges (no station to address, and the user already
+    knows their own home). Both temperatures come from the car's own telemetry
+    (positions.outside_temp / battery_min_temp) nearest each endpoint's timestamp
+    (get_position_near) — charges have no Open-Meteo weather enrichment like trips do
+    (elevation_enrich), so 🌡️ here can be blank on cars that don't report an
+    ambient-temperature signal at all. Live network calls (geocoding, station lookup) —
+    safe for the 🧭 button (one charge) and for the automatic call at charge-close
+    (poller/recorder.py, one NEW charge at a time), never a historical backfill sweep.
+    `only_if_note_empty` is the automatic-at-close guard: a manual note the user already
+    typed is never clobbered by this running just after; the manual button always
+    overwrites (the UI confirms with the user first when there's something to lose — see
+    charge_card.html's hx-confirm)."""
+    import charger_locator
+    import units
+    row = _get().execute("SELECT * FROM charges WHERE id=? AND vehicle_id = COALESCE(?, vehicle_id)",
+                         (charge_id, _current_vehicle_id())).fetchone()
+    if not row:
+        return None
+    row = dict(row)
+    if only_if_note_empty and (row.get("note") or "").strip():
+        return row.get("note")
+    address = None
+    if (row.get("location_type") != "HOME"
+            and row.get("latitude") is not None and row.get("longitude") is not None):
+        options, _ok = charger_locator.find_station_candidates(row["latitude"], row["longitude"])
+        match = next((o for o in options if o.get("name") == row.get("location_name")), None)
+        address = (match or {}).get("address")
+        if not address:
+            # The name-matched option (or none, if the saved name came from a source no
+            # longer offered) can still lack a street address even though a DIFFERENT
+            # source at the very same physical site has one — charger_locator keeps
+            # differently-named sources as separate options on purpose (its own docstring:
+            # lets the manual relocate button offer a real choice), so an address one
+            # network reports isn't automatically inherited by another's option. Borrow the
+            # nearest option that has one — options are already distance-sorted, and it's
+            # the same charging site either way.
+            address = next((o["address"] for o in options if o.get("address")), None)
+    start_dt = _local_dt(row.get("started_at"))
+    end_dt = _local_dt(row.get("ended_at"))
+    p_start = get_position_near(row.get("started_at"))
+    p_end = get_position_near(row.get("ended_at"))
+
+    def _temps(pos) -> str:
+        if not pos:
+            return ""
+        bits = []
+        if pos.get("outside_temp") is not None:
+            bits.append(f"🌡️ {units.temp(pos['outside_temp'])}")
+        if pos.get("battery_min_temp") is not None:
+            bits.append(f"🔋 {units.temp(pos['battery_min_temp'])}")
+        return " · ".join(bits)
+
+    def _line(marker: str, addr, dt, pos) -> "str | None":
+        if not dt:
+            return None
+        bits = ([addr] if addr else []) + [dt.strftime("%H:%M")]
+        t = _temps(pos)
+        if t:
+            bits.append(t)
+        text = " · ".join(bits)
+        return f"{marker} {text}" if marker else text
+
+    lines = [_line("", address, start_dt, p_start),
+             _line("→", None, end_dt, p_end)]
+    text = (" ".join(l for l in lines if l) or None)
+    if text:
+        text = text.strip()[:1000]
+    db = _conn_rw()
+    db.execute("UPDATE charges SET note=? WHERE id=?", (text, charge_id))
+    db.commit()
+    return text
+
+
 def _charge_active_window(db, started_at, ended_at):
     """First & last sample with REAL charging power (positions.charging=1, which is set only when power
     flows — NOT on plug-in) inside the session window. Returns (start_utc_iso, end_utc_iso), or

--- a/web/locales/de.json
+++ b/web/locales/de.json
@@ -417,6 +417,8 @@
     "note_ph_trip": "Verkehr, Wetter, Streckentyp, persönliche Anmerkungen…",
     "note_save": "Speichern",
     "note_saved": "Gespeichert",
+    "auto_note_generate_btn": "Zusammenfassung erstellen (Adresse, Uhrzeit, Temperatur)",
+    "auto_note_overwrite_confirm": "Beim Erstellen der automatischen Zusammenfassung wird der aktuelle Notiztext ersetzt. Fortfahren?",
     "drive_mode": "Fahrmodus",
     "one_pedal": "One-Pedal",
     "mode_comfort": "Comfort",

--- a/web/locales/en.json
+++ b/web/locales/en.json
@@ -471,6 +471,8 @@
     "note_ph_trip": "Traffic, weather, road type, personal remarks…",
     "note_save": "Save",
     "note_saved": "Saved",
+    "auto_note_generate_btn": "Generate summary (address, time, temperature)",
+    "auto_note_overwrite_confirm": "Generating the automatic summary will replace the current note text. Continue?",
     "drive_mode": "Drive mode",
     "one_pedal": "One-Pedal",
     "mode_comfort": "Comfort",

--- a/web/locales/fr.json
+++ b/web/locales/fr.json
@@ -471,6 +471,8 @@
     "note_ph_trip": "Trafic, météo, type de route, remarques personnelles…",
     "note_save": "Enregistrer",
     "note_saved": "Enregistré",
+    "auto_note_generate_btn": "Générer un résumé (adresse, heure, température)",
+    "auto_note_overwrite_confirm": "La génération du résumé automatique remplacera le texte actuel de la note. Continuer ?",
     "drive_mode": "Mode de conduite",
     "one_pedal": "One-Pedal",
     "mode_comfort": "Confort",

--- a/web/locales/it.json
+++ b/web/locales/it.json
@@ -471,6 +471,8 @@
     "note_ph_trip": "Traffico, meteo, tipo di strada, note personali…",
     "note_save": "Salva",
     "note_saved": "Salvato",
+    "auto_note_generate_btn": "Genera riepilogo (indirizzo, ora, temperatura)",
+    "auto_note_overwrite_confirm": "Generando il riepilogo automatico il testo attuale della nota verrà sostituito. Continuare?",
     "drive_mode": "Modalità di guida",
     "one_pedal": "One-Pedal",
     "mode_comfort": "Comfort",

--- a/web/locales/pl.json
+++ b/web/locales/pl.json
@@ -406,6 +406,8 @@
     "note_ph_trip": "Ruch, pogoda, typ drogi, uwagi osobiste…",
     "note_save": "Zapisz",
     "note_saved": "Zapisano",
+    "auto_note_generate_btn": "Wygeneruj podsumowanie (adres, godzina, temperatura)",
+    "auto_note_overwrite_confirm": "Wygenerowanie automatycznego podsumowania zastąpi obecny tekst notatki. Kontynuować?",
     "drive_mode": "Tryb jazdy",
     "one_pedal": "One-Pedal",
     "mode_comfort": "Comfort",

--- a/web/locales/pt-PT.json
+++ b/web/locales/pt-PT.json
@@ -471,6 +471,8 @@
     "note_ph_trip": "Trânsito, meteorologia, tipo de estrada, observações pessoais…",
     "note_save": "Guardar",
     "note_saved": "Guardado",
+    "auto_note_generate_btn": "Gerar resumo (endereço, hora, temperatura)",
+    "auto_note_overwrite_confirm": "Ao gerar o resumo automático, o texto atual da nota será substituído. Continuar?",
     "drive_mode": "Modo de condução",
     "one_pedal": "One-Pedal",
     "mode_comfort": "Conforto",

--- a/web/main.py
+++ b/web/main.py
@@ -704,6 +704,25 @@ async def set_trip_note(request: Request, trip_id: int):
     return HTMLResponse("✓ " + i18n.get_t(db_reader.get_language())("note_saved"))
 
 
+@app.post("/api/trips/{trip_id}/auto-note", response_class=HTMLResponse)
+async def trip_generate_auto_note(request: Request, trip_id: int):
+    """🧭 manual 'Generate' button: builds the start/end address+time+temperature summary
+    and writes it straight into the trip's note field, replacing whatever was there (the UI
+    confirms with the user first when there was something to lose — trip_detail.html's
+    conditional hx-confirm). Reverse-geocoding is a live network call (Nominatim's usage
+    policy forbids bulk/automated lookups), so this only ever runs on a click for THIS one
+    trip — never a background sweep. Swaps in just the textarea, so the Salva button below
+    still submits the fresh text normally."""
+    import asyncio
+    provider = db_reader.get_setting("geocoder_provider", "")
+    key = db_reader.get_secret("geocoder_key", "") or None
+    note = await asyncio.get_event_loop().run_in_executor(
+        None, db_reader.generate_trip_auto_note, trip_id, provider, key)
+    t = i18n.get_t(db_reader.get_language())
+    return templates.TemplateResponse(request, "partials/trip_note_textarea.html",
+                                      {"trip": {"id": trip_id, "note": note}, "t": t})
+
+
 @app.delete("/api/charges/{charge_id}")
 async def delete_charge(request: Request, charge_id: int):
     """Permanently delete one charge session (HTMX, confirmed in the UI). Reloads the charges list,
@@ -720,6 +739,25 @@ async def set_charge_note(request: Request, charge_id: int):
     form = await request.form()
     db_reader.save_charge_note(charge_id, form.get("note") or "")
     return HTMLResponse("✓ " + i18n.get_t(db_reader.get_language())("note_saved"))
+
+
+@app.post("/api/charges/{charge_id}/auto-note", response_class=HTMLResponse)
+async def charge_generate_auto_note(request: Request, charge_id: int):
+    """🧭 manual 'Generate' button: builds the station-address + start/end time+temperature
+    summary and writes it straight into the charge's note field, replacing whatever was
+    there (the UI confirms with the user first when there was something to lose —
+    charge_card.html's conditional hx-confirm). Both the station lookup and the
+    reverse-geocoding a HOME charge skips are live network calls, so this only ever runs
+    on a click for THIS one charge — never a background sweep. Swaps in just the
+    textarea, so the Salva button below still submits the fresh text normally."""
+    import asyncio
+    provider = db_reader.get_setting("geocoder_provider", "")
+    key = db_reader.get_secret("geocoder_key", "") or None
+    note = await asyncio.get_event_loop().run_in_executor(
+        None, db_reader.generate_charge_auto_note, charge_id, provider, key)
+    t = i18n.get_t(db_reader.get_language())
+    return templates.TemplateResponse(request, "partials/charge_note_textarea.html",
+                                      {"c": {"id": charge_id, "note": note}, "t": t})
 
 
 @app.get("/charges", response_class=HTMLResponse)

--- a/web/templates/partials/charge_card.html
+++ b/web/templates/partials/charge_card.html
@@ -173,13 +173,22 @@
 
   <!-- User note (#107) — free-text context the raw data can't capture -->
   <div class="mt-3">
-    <label class="stat-label" style="font-size:10px">📝 {{ t('user_note') }}</label>
+    <div class="flex items-center justify-between">
+      <label class="stat-label" style="font-size:10px">📝 {{ t('user_note') }}</label>
+      <button type="button" title="{{ t('auto_note_generate_btn') }}"
+              hx-post="api/charges/{{ c.id }}/auto-note"
+              hx-target="#charge-note-text-{{ c.id }}" hx-swap="outerHTML"
+              hx-disabled-elt="this" hx-indicator="#charge-auto-note-spin-{{ c.id }}"
+              {% if c.note %}hx-confirm="{{ t('auto_note_overwrite_confirm') }}"{% endif %}
+              class="text-slate-500 hover:text-brand disabled:opacity-40"
+              style="background:none;border:none;cursor:pointer;padding:0;font-size:12px;line-height:1">
+        <span id="charge-auto-note-spin-{{ c.id }}" class="htmx-indicator">⏳</span><span>🧭</span>
+      </button>
+    </div>
     <form class="mt-1" hx-post="api/charges/{{ c.id }}/note"
           hx-target="#cnote-msg-{{ c.id }}" hx-swap="innerHTML"
           hx-on::after-request="if(event.detail.successful){var m=document.getElementById('cnote-msg-{{ c.id }}');setTimeout(function(){if(m)m.textContent='';},2500);}">
-      <textarea name="note" rows="2" maxlength="1000"
-                placeholder="{{ t('note_ph_charge') }}"
-                style="width:100%;background:#0f172a;border:1px solid #334155;border-radius:8px;padding:8px 10px;font-size:12px;color:#e2e8f0;resize:vertical">{{ c.note or '' }}</textarea>
+      {% include "partials/charge_note_textarea.html" %}
       <div class="flex items-center gap-2 mt-1">
         <button type="submit"
                 style="background:#1e293b;border:1px solid #334155;border-radius:6px;padding:3px 12px;font-size:11px;color:#94a3b8;cursor:pointer"

--- a/web/templates/partials/charge_note_textarea.html
+++ b/web/templates/partials/charge_note_textarea.html
@@ -1,0 +1,7 @@
+{# The charge note textarea — its own partial so the 🧭 auto-note button (main.py's
+   charge_generate_auto_note) can swap just this element after writing a fresh summary
+   into c.note, without re-rendering the surrounding form/buttons. Expects `c` and `t`. #}
+<textarea name="note" rows="2" maxlength="1000"
+          id="charge-note-text-{{ c.id }}"
+          placeholder="{{ t('note_ph_charge') }}"
+          style="width:100%;background:#0f172a;border:1px solid #334155;border-radius:8px;padding:8px 10px;font-size:12px;color:#e2e8f0;resize:vertical">{{ c.note or '' }}</textarea>

--- a/web/templates/partials/trip_note_textarea.html
+++ b/web/templates/partials/trip_note_textarea.html
@@ -1,0 +1,7 @@
+{# The trip note textarea — its own partial so the 🧭 auto-note button (main.py's
+   trip_generate_auto_note) can swap just this element after writing a fresh summary into
+   trip.note, without re-rendering the surrounding form/buttons. Expects `trip` and `t`. #}
+<textarea name="note" rows="3" maxlength="1000"
+          id="trip-note-text-{{ trip.id }}"
+          placeholder="{{ t('note_ph_trip') }}"
+          class="w-full bg-slate-900 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 resize-y focus:border-brand focus:outline-none">{{ trip.note or '' }}</textarea>

--- a/web/templates/trip_detail.html
+++ b/web/templates/trip_detail.html
@@ -252,12 +252,21 @@
     <!-- User note + manual driving tags (#107). Drive mode & One-Pedal are MANUAL: the Leapmotor
          cloud doesn't expose them (verified on-car), so the user tags them to explain consumption. -->
     <div class="card">
-      <h2 class="font-semibold text-white text-sm mb-3">📝 {{ t('user_note') }}</h2>
+      <div class="flex items-center justify-between mb-3">
+        <h2 class="font-semibold text-white text-sm">📝 {{ t('user_note') }}</h2>
+        <button type="button" title="{{ t('auto_note_generate_btn') }}"
+                hx-post="api/trips/{{ trip.id }}/auto-note"
+                hx-target="#trip-note-text-{{ trip.id }}" hx-swap="outerHTML"
+                hx-disabled-elt="this" hx-indicator="#trip-auto-note-spin-{{ trip.id }}"
+                {% if trip.note %}hx-confirm="{{ t('auto_note_overwrite_confirm') }}"{% endif %}
+                class="text-slate-500 hover:text-brand disabled:opacity-40"
+                style="background:none;border:none;cursor:pointer;padding:0;font-size:14px;line-height:1">
+          <span id="trip-auto-note-spin-{{ trip.id }}" class="htmx-indicator">⏳</span><span>🧭</span>
+        </button>
+      </div>
       <form hx-post="api/trips/{{ trip.id }}/note" hx-target="#trip-note-msg" hx-swap="innerHTML"
             hx-on::after-request="if(event.detail.successful){var m=document.getElementById('trip-note-msg');setTimeout(function(){if(m)m.textContent='';},2500);}">
-        <textarea name="note" rows="3" maxlength="1000"
-                  placeholder="{{ t('note_ph_trip') }}"
-                  class="w-full bg-slate-900 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 resize-y focus:border-brand focus:outline-none">{{ trip.note or '' }}</textarea>
+        {% include "partials/trip_note_textarea.html" %}
 
         <div class="grid grid-cols-2 gap-3 mt-3">
           <div>


### PR DESCRIPTION
EN
--
A 🧭 button on trips and charges builds a one-line summary — address, time, and temperature(s) — and writes it straight into the existing note field. Trips: reverse-geocoded start/end address + the trip's own Open-Meteo weather temperature. Charges: the station address (reused from the same OSM/OCM lookup the 📍 label already runs; skipped for HOME) + start/end time with the car's own outside/battery telemetry nearest each instant.

New trips and charges get this generated automatically the moment they close (live close, or a reconstructed trip/charge from an offline gap) — but only into an EMPTY note, never overwriting anything the user already typed. The manual button always overwrites; when there's an existing note to lose, the UI shows a native confirm popup first.

Two bugs found and fixed along the way:
- The charge address could come back blank even when a real address was known: the code only checked the ONE candidate whose name matched the charge's saved label, and that specific source can lack a street address even though a different source at the exact same physical site has one. Now falls back to the nearest candidate that has an address.
- The 🧭 button's own loading spinner could get stuck on forever. Root cause: htmx 1.9's hx-disabled-elt and its default indicator both resolved to the button itself and share one internal reference count; on request completion the count could land on 1 instead of 0, so the "request in flight" class was never removed. Fixed by pointing hx-indicator at the spinner span explicitly, decoupling it from hx-disabled-elt's counter.

CRITICAL / trade-offs
- Reverse-geocoding (Nominatim) and the station lookup (OSM Overpass/OCM) are live network calls with no caching. Automatic generation fires once per NEW trip/charge as it closes — never a historical backfill sweep — matching Nominatim's usage policy against bulk/automated lookups. The automatic path also runs off a background thread so it never delays the poller's next status poll.
- A trip's weather temperature depends on Open-Meteo enrichment having already run, which may not be true the instant the trip closes. The note then simply omits that figure; pressing 🧭 again later regenerates it.
- The design was simplified mid-implementation: an earlier version kept a separate read-only summary line above a still-fully-manual note. That added a second field to keep in sync for no real benefit — the current version writes straight into the one note field instead.

IT
--
Un pulsante 🧭 su viaggi e ricariche genera un riepilogo su una riga — indirizzo, orario e temperatura/e — scrivendolo direttamente nel campo nota esistente. Viaggi: indirizzo di partenza/arrivo (geocodifica inversa)
+ la temperatura meteo già raccolta per quel viaggio (Open-Meteo). Ricariche: indirizzo della colonnina (stessa ricerca OSM/OCM già usata per l'etichetta 📍; saltata per le ricariche HOME) + orario di inizio/fine con le temperature (esterna/batteria) rilevate dall'auto in quegli istanti.

Per i viaggi e le ricariche NUOVI la nota viene generata automaticamente appena il record si chiude (chiusura live, oppure viaggio/ricarica ricostruiti da un buco offline) — ma solo se la nota è vuota, senza mai sovrascrivere testo già scritto dall'utente. Il pulsante manuale sovrascrive sempre; se c'è già una nota da perdere, l'interfaccia mostra prima un popup di conferma nativo del browser.

Due bug trovati e corretti nel percorso:
- L'indirizzo della ricarica poteva risultare vuoto anche quando un indirizzo reale era disponibile: il codice controllava solo l'UNICA opzione con nome corrispondente all'etichetta salvata, e proprio quella fonte può non avere l'indirizzo anche se un'altra fonte sulla STESSA colonnina fisica ce l'ha. Ora si ripiega sull'opzione più vicina che ha un indirizzo.
- La clessidra di caricamento del pulsante 🧭 poteva restare visibile per sempre. Causa: in htmx 1.9 l'attributo hx-disabled-elt e l'indicatore di caricamento predefinito puntavano entrambi al bottone stesso e condividono un unico contatore interno; a fine richiesta il contatore poteva fermarsi a 1 invece che 0, quindi la classe "richiesta in corso" non veniva mai rimossa. Risolto puntando hx-indicator esplicitamente allo span della clessidra, separandolo dal contatore di hx-disabled-elt.

CRITICO / compromessi
- La geocodifica inversa (Nominatim) e la ricerca colonnina (OSM Overpass/OCM) sono chiamate di rete live, senza cache. La generazione automatica scatta una volta per ogni NUOVO viaggio/ricarica alla chiusura — mai una scansione retroattiva sullo storico — rispettando le policy di Nominatim contro le ricerche massive/automatizzate. Il percorso automatico gira anche su un thread separato per non ritardare mai il prossimo poll del poller.
- La temperatura meteo di un viaggio dipende dall'arricchimento Open-Meteo già avvenuto, cosa non garantita nell'istante in cui il viaggio si chiude. In quel caso la nota omette semplicemente quel dato; premendo di nuovo 🧭 in seguito viene rigenerata.
- Il design è stato semplificato a metà implementazione: una versione precedente manteneva una riga di riepilogo separata, di sola lettura, sopra una nota comunque interamente manuale. Questo aggiungeva un secondo campo da tenere sincronizzato senza un reale vantaggio — la versione attuale scrive direttamente nell'unico campo nota.