### PR TITLE
Fix CSV export to handle merged trips without errors

### DIFF
--- a/tests/test_export_csv.py
+++ b/tests/test_export_csv.py
@@ -1,0 +1,100 @@
+"""CSV export (Viaggi/Ricariche "Esporta CSV") — regression: a merged trip's dict carries
+an extra "segment_ids" key (_trip_group_stats, only present when there ARE merged
+segments) that the FIRST trip in the list may not have. csv.DictWriter's default fieldnames
+= first row's keys, so it raised ValueError the moment it reached a merged trip later in
+the list — a real 500 a user hit clicking "Esporta CSV" on Viaggi the moment their history
+contained even one merged trip, silently reproducing the bug every time until fixed here.
+"""
+import asyncio
+import csv
+import io
+
+import pytest
+
+import db as D
+import db_reader
+
+
+def _setup(tmp_path, monkeypatch):
+    pdb = D.Database(str(tmp_path / "t.db"))
+    monkeypatch.setattr(db_reader, "DB_PATH", str(tmp_path / "t.db"))
+    return pdb
+
+
+def _seed_trip(pdb, tid, started, *, ended=None, km=10.0, eff=18.0, merged_into=None):
+    pdb._conn.execute(
+        "INSERT INTO trips (id, vehicle_id, started_at, ended_at, distance_km, start_soc, end_soc,"
+        " efficiency_kwh_100km, duration_min, merged_into_id) VALUES (?,1,?,?,?,?,?,?,?,?)",
+        (tid, started, ended or started, km, 60, 50, eff, 15.0, merged_into))
+    pdb._conn.commit()
+
+
+# ── _csv_response: the general fix ────────────────────────────────────────────────
+
+def test_csv_response_handles_rows_with_different_key_sets():
+    pytest.importorskip("fastapi", reason="web.main needs fastapi (absent in the minimal CI test env)")
+    import main
+    rows = [{"id": 1, "distance_km": 10.0}, {"id": 2, "distance_km": 20.0, "segment_ids": [2, 3]}]
+
+    resp = main._csv_response(rows, "test.csv")
+
+    reader = csv.DictReader(io.StringIO(resp.body.decode()))
+    assert reader.fieldnames == ["id", "distance_km"]   # segment_ids dropped, no crash
+    out = list(reader)
+    assert out[0]["id"] == "1" and out[1]["id"] == "2"
+
+
+def test_csv_response_drops_list_and_dict_valued_fields():
+    pytest.importorskip("fastapi", reason="web.main needs fastapi (absent in the minimal CI test env)")
+    import main
+    rows = [{"id": 1, "tags": ["a", "b"], "meta": {"k": "v"}, "note": "fine"}]
+
+    resp = main._csv_response(rows, "test.csv")
+
+    reader = csv.DictReader(io.StringIO(resp.body.decode()))
+    assert reader.fieldnames == ["id", "note"]
+
+
+def test_csv_response_empty_rows_returns_just_headers_row_none():
+    pytest.importorskip("fastapi", reason="web.main needs fastapi (absent in the minimal CI test env)")
+    import main
+    resp = main._csv_response([], "test.csv")
+    assert resp.body.decode() == ""
+
+
+# ── export_trips_csv: end-to-end regression ──────────────────────────────────────
+
+def test_export_trips_csv_does_not_crash_with_a_merged_trip(tmp_path, monkeypatch):
+    pytest.importorskip("fastapi", reason="web.main needs fastapi (absent in the minimal CI test env)")
+    import main
+    pdb = _setup(tmp_path, monkeypatch)
+    monkeypatch.setattr(main.db_reader, "DB_PATH", str(tmp_path / "t.db"))
+    # trip 1 has NO children (no segment_ids key) and sorts FIRST (most recent) —
+    # exactly the ordering that broke csv.DictWriter's default fieldnames.
+    _seed_trip(pdb, 1, "2026-07-10T10:00:00+00:00")
+    _seed_trip(pdb, 2, "2026-07-01T10:00:00+00:00")           # merge parent
+    _seed_trip(pdb, 3, "2026-07-01T10:20:00+00:00", merged_into=2)   # merge child
+
+    resp = asyncio.run(main.export_trips_csv())
+
+    body = resp.body.decode()
+    reader = csv.DictReader(io.StringIO(body))
+    rows = list(reader)
+    assert "segment_ids" not in reader.fieldnames
+    assert {r["id"] for r in rows} == {"1", "2"}   # merged child (3) not listed on its own
+
+
+def test_export_charges_csv_still_works(tmp_path, monkeypatch):
+    pytest.importorskip("fastapi", reason="web.main needs fastapi (absent in the minimal CI test env)")
+    import main
+    pdb = _setup(tmp_path, monkeypatch)
+    monkeypatch.setattr(main.db_reader, "DB_PATH", str(tmp_path / "t.db"))
+    pdb._conn.execute(
+        "INSERT INTO charges (id, vehicle_id, started_at, ended_at, start_soc, end_soc)"
+        " VALUES (1,1,'2026-07-01T10:00:00+00:00','2026-07-01T10:30:00+00:00',40,80)")
+    pdb._conn.commit()
+
+    resp = asyncio.run(main.export_charges_csv())
+
+    rows = list(csv.DictReader(io.StringIO(resp.body.decode())))
+    assert rows[0]["id"] == "1"

--- a/web/main.py
+++ b/web/main.py
@@ -2844,12 +2844,23 @@ async def save_retention(request: Request):
 
 
 def _csv_response(rows: list, filename: str) -> Response:
+    """Rows can carry different key sets — e.g. get_trips()'s "segment_ids" only appears on
+    merged trips — and csv.DictWriter crashes (500) the moment a later row has a key the
+    FIRST row's fieldnames didn't cover. Union every row's keys instead, in first-seen
+    order, and drop list/dict-typed values (segment_ids is internal merge bookkeeping, not
+    something a CSV export needs — and would otherwise show as a raw Python repr)."""
     import csv, io
     buf = io.StringIO()
     if rows:
-        w = csv.DictWriter(buf, fieldnames=list(rows[0].keys()))
+        fieldnames = []
+        for r in rows:
+            for k, v in r.items():
+                if k not in fieldnames and not isinstance(v, (list, dict)):
+                    fieldnames.append(k)
+        clean_rows = [{k: v for k, v in r.items() if k in fieldnames} for r in rows]
+        w = csv.DictWriter(buf, fieldnames=fieldnames)
         w.writeheader()
-        w.writerows(rows)
+        w.writerows(clean_rows)
     return Response(buf.getvalue(), media_type="text/csv; charset=utf-8",
                     headers={"Content-Disposition": f'attachment; filename="{filename}"'})
 


### PR DESCRIPTION
EN
--
Clicking "Export CSV" on Viaggi could return a page whose entire body was the literal text "Internal Server Error" instead of a file. Root cause: get_trips() adds a "segment_ids" key to a trip's dict ONLY when it's a merge parent with children (_trip_group_stats) — an un-merged trip's dict doesn't have it. csv.DictWriter takes its column set from the FIRST row only; the moment the export reached a merged trip anywhere else in the (most-recent-first) list, it raised ValueError("dict contains fields not in fieldnames") on a key the first row never had, and FastAPI turned that into a 500. Any user with even one merged trip in their history — a one-click reversible action already offered elsewhere in the app — would hit this on every single export attempt, not intermittently.

Fixed in the shared _csv_response() (also used by Charges' own CSV export): the column set is now the union of every row's keys, gathered in first-seen order, and any list/dict-valued field is dropped rather than written as a raw Python repr — segment_ids is internal merge bookkeeping, not something a CSV export needs to show.

CRITICAL / trade-offs
- Neither export endpoint had a single test before this. That's how a crash reachable by clicking one button, with completely ordinary data (anyone who has ever used the Viaggi merge feature), went unnoticed. Added 5 tests: the general fix (mismatched keys, non-scalar values, empty input) plus an end-to-end regression seeding a merged trip that sorts BEFORE its own parent in the export — the exact ordering that broke it.
- The fix is general (any current or future field that only appears on some rows is now handled the same way), not a special case for "segment_ids" — so a similar field added later to either export won't reopen this exact bug.
- Found reactively, from the user pasting the actual downloaded file content ("Internal Server Error") rather than a report of an unlikely edge case — worth registering that neither CSV export had ever been exercised against real merged-trip history before now.

IT
--
Cliccare "Esporta CSV" su Viaggi poteva restituire una pagina il cui intero contenuto era il testo letterale "Internal Server Error" invece di un file. Causa: get_trips() aggiunge la chiave "segment_ids" al dizionario di un viaggio SOLO quando è un genitore di unione con figli (_trip_group_stats) — un viaggio non unito non ce l'ha. csv.DictWriter prende l'insieme delle colonne dalla PRIMA riga soltanto; nel momento in cui l'export raggiungeva un viaggio unito in un punto qualsiasi della lista (ordinata dal più recente), sollevava ValueError("dict contains fields not in fieldnames") su una chiave che la prima riga non aveva mai avuto, e FastAPI la trasformava in un 500. Chiunque avesse anche un solo viaggio unito nella propria cronologia — un'azione reversibile con un click, già offerta altrove nell'app — incontrava questo problema ad ogni singolo tentativo di esportazione, non in modo intermittente.

Corretto nella funzione condivisa _csv_response() (usata anche dall'esportazione CSV delle Ricariche): l'insieme delle colonne ora è l'unione delle chiavi di TUTTE le righe, raccolte nell'ordine di prima comparsa, e qualsiasi campo di tipo lista/dizionario viene scartato invece di essere scritto come rappresentazione grezza Python — segment_ids è contabilità interna delle unioni, non qualcosa che un'esportazione CSV deve mostrare.

CRITICO / compromessi
- Nessuno dei due endpoint di esportazione aveva un solo test prima di questo fix. È così che un crash raggiungibile cliccando un bottone, con dati assolutamente ordinari (chiunque abbia mai usato la funzione di unione viaggi), è passato inosservato. Aggiunti 5 test: il fix generale (chiavi non corrispondenti, valori non scalari, input vuoto) più una regressione end-to-end che genera un viaggio unito ordinato PRIMA del proprio genitore nell'export — esattamente l'ordinamento che causava il crash.
- Il fix è generale (qualsiasi campo presente o futuro che compare solo su alcune righe viene ora gestito allo stesso modo), non un caso speciale per "segment_ids" — quindi un campo simile aggiunto in futuro a uno dei due export non riaprirà esattamente questo bug.
- Scoperto in modo reattivo, dall'utente che ha incollato il contenuto reale del file scaricato ("Internal Server Error") piuttosto che da una segnalazione di un caso limite improbabile — vale la pena registrare che nessuno dei due export CSV era mai stato esercitato contro una vera cronologia con viaggi uniti prima d'ora.