### PR TITLE
Add manual station name input for missing OSM/OCM charges

### DIFF
--- a/tests/test_charge_relocate.py
+++ b/tests/test_charge_relocate.py
@@ -164,3 +164,72 @@ def test_the_two_empty_answers_read_differently(env):
         tl = i18n.get_t(lang)
         for key in ("charger_locator_relocate_kept", "charger_locator_relocate_none"):
             assert tl(key) != key, f"{lang} is missing {key}"
+
+
+# ── ✏️ manual station name (#193: "Where to add stationname") ────────────────────
+
+def test_manual_name_is_saved(env):
+    main, fake, add_charge, answer = env
+    cid = add_charge()
+
+    class Form(_Req):
+        async def form(self):
+            return {"name": "Colonnina del bar Mario"}
+
+    asyncio.run(main.set_manual_charge_location(Form(), cid))
+
+    row = db_reader.get_charge_location(cid)
+    assert row["location_name"] == "Colonnina del bar Mario"
+    assert row["location_url"] is None   # a hand-typed name never has a source link
+
+
+def test_manual_name_removes_the_charge_from_the_sweep_queue(env):
+    """location_name IS NOT NULL either way — set_charge_location_name is the SAME write
+    path the automatic sweep and the candidate-picker use, so this charge drops out of
+    get_location_lookup_candidates exactly like an auto-resolved name would."""
+    main, fake, add_charge, answer = env
+    cid = add_charge()
+    assert any(c["id"] == cid for c in db_reader.get_location_lookup_candidates())
+
+    class Form(_Req):
+        async def form(self):
+            return {"name": "Colonnina del bar Mario"}
+
+    asyncio.run(main.set_manual_charge_location(Form(), cid))
+
+    assert not any(c["id"] == cid for c in db_reader.get_location_lookup_candidates())
+
+
+def test_empty_submission_leaves_an_existing_name_untouched(env):
+    main, fake, add_charge, answer = env
+    cid = add_charge(name="Old name", url="https://old/1")
+
+    class Form(_Req):
+        async def form(self):
+            return {"name": "  "}   # whitespace-only, same as leaving the field blank
+
+    asyncio.run(main.set_manual_charge_location(Form(), cid))
+
+    row = db_reader.get_charge_location(cid)
+    assert row["location_name"] == "Old name"
+    assert row["location_url"] == "https://old/1"
+
+
+def test_manual_name_on_a_missing_charge_returns_404(env):
+    main, fake, add_charge, answer = env
+
+    class Form(_Req):
+        async def form(self):
+            return {"name": "Anything"}
+
+    resp = asyncio.run(main.set_manual_charge_location(Form(), 999))
+
+    assert resp.status_code == 404
+
+
+def test_manual_entry_strings_present_in_every_locale():
+    import i18n
+    for lang in ("en", "it", "de", "fr", "pl", "pt-PT"):
+        t = i18n.get_t(lang)
+        for key in ("charger_locator_manual_hint", "charger_locator_manual_ph"):
+            assert t(key) != key, f"{lang} is missing {key}"

--- a/web/locales/de.json
+++ b/web/locales/de.json
@@ -198,6 +198,8 @@
     "charger_locator_relocate_kept": "Keine Ladestation gefunden — Name unverändert",
     "charger_locator_pick": "Diese Station hat mehrere Lademöglichkeiten, wähle deine:",
     "charger_locator_cancel": "Abbrechen",
+    "charger_locator_manual_hint": "Namen der Ladestation manuell eingeben",
+    "charger_locator_manual_ph": "Name der Ladestation…",
     "nav_find_chargers": "Ladestationen finden",
     "nav_charger_radius": "Max. Entfernung (km)",
     "nav_charger_count": "Ergebnisse pro Seite",

--- a/web/locales/en.json
+++ b/web/locales/en.json
@@ -198,6 +198,8 @@
     "charger_locator_relocate_kept": "No station found — name left as it was",
     "charger_locator_pick": "This station has more than one charging option, pick yours:",
     "charger_locator_cancel": "Cancel",
+    "charger_locator_manual_hint": "Type the station's name manually",
+    "charger_locator_manual_ph": "Station name…",
     "nav_find_chargers": "Find charging stations",
     "nav_charger_radius": "Max distance (km)",
     "nav_charger_count": "Results per page",

--- a/web/locales/fr.json
+++ b/web/locales/fr.json
@@ -198,6 +198,8 @@
     "charger_locator_relocate_kept": "Aucune borne trouvée — nom inchangé",
     "charger_locator_pick": "Cette borne propose plusieurs options de recharge, choisissez la vôtre :",
     "charger_locator_cancel": "Annuler",
+    "charger_locator_manual_hint": "Saisir manuellement le nom de la borne",
+    "charger_locator_manual_ph": "Nom de la borne…",
     "nav_find_chargers": "Trouver des bornes",
     "nav_charger_radius": "Distance max. (km)",
     "nav_charger_count": "Résultats par page",

--- a/web/locales/it.json
+++ b/web/locales/it.json
@@ -198,6 +198,8 @@
     "charger_locator_relocate_kept": "Nessuna colonnina trovata — nome invariato",
     "charger_locator_pick": "Questa colonnina ha più opzioni di ricarica, scegli la tua:",
     "charger_locator_cancel": "Annulla",
+    "charger_locator_manual_hint": "Inserisci manualmente il nome della colonnina",
+    "charger_locator_manual_ph": "Nome colonnina…",
     "nav_find_chargers": "Trova colonnine",
     "nav_charger_radius": "Distanza massima (km)",
     "nav_charger_count": "Risultati per pagina",

--- a/web/locales/pl.json
+++ b/web/locales/pl.json
@@ -198,6 +198,8 @@
     "charger_locator_relocate_kept": "Nie znaleziono stacji — nazwa bez zmian",
     "charger_locator_pick": "Ta stacja ma kilka opcji ładowania, wybierz swoją:",
     "charger_locator_cancel": "Anuluj",
+    "charger_locator_manual_hint": "Wpisz nazwę stacji ręcznie",
+    "charger_locator_manual_ph": "Nazwa stacji…",
     "nav_find_chargers": "Znajdź stacje ładowania",
     "nav_charger_radius": "Maks. odległość (km)",
     "nav_charger_count": "Wyniki na stronę",

--- a/web/locales/pt-PT.json
+++ b/web/locales/pt-PT.json
@@ -198,6 +198,8 @@
     "charger_locator_relocate_kept": "Nenhum posto encontrado — nome inalterado",
     "charger_locator_pick": "Esta estação tem mais do que uma opção de carregamento, escolha a sua:",
     "charger_locator_cancel": "Cancelar",
+    "charger_locator_manual_hint": "Introduzir manualmente o nome do posto de carregamento",
+    "charger_locator_manual_ph": "Nome do posto…",
     "nav_find_chargers": "Encontrar estações de carregamento",
     "nav_charger_radius": "Distância máxima (km)",
     "nav_charger_count": "Resultados por página",

--- a/web/main.py
+++ b/web/main.py
@@ -2561,6 +2561,28 @@ async def cancel_charge_location(request: Request, charge_id: int):
                                       {"charge": charge or {"id": charge_id}, "t": t})
 
 
+@app.post("/api/charges/{charge_id}/locate/manual", response_class=HTMLResponse)
+async def set_manual_charge_location(request: Request, charge_id: int):
+    """✏️ free-text station name — for a station OSM/OCM simply doesn't have (#193:
+    "Where to add stationname"). No coordinates/URL involved, just the label the
+    automatic lookup could never produce on its own. Persists through
+    set_charge_location_name exactly like a picked candidate would — location_name
+    IS NOT NULL either way, so the background sweep (_LOCATION_CANDIDATES_WHERE) never
+    revisits this charge. An empty submission changes nothing (closes the input with
+    whatever was already saved, same as clicking away)."""
+    form = await request.form()
+    name = (form.get("name") or "").strip()[:200]
+    charge = db_reader.get_charge_location(charge_id)
+    if not charge:
+        return HTMLResponse("", status_code=404)
+    if name:
+        db_reader.set_charge_location_name(charge_id, name, None)
+        charge["location_name"], charge["location_url"] = name, None
+    t = i18n.get_t(db_reader.get_language())
+    return templates.TemplateResponse(request, "partials/charge_location.html",
+                                      {"charge": charge, "t": t})
+
+
 def _wallbox_overlay(curve: dict, charge_id: int) -> list | None:
     """Wallbox power (from HA history) resampled onto the car curve's timestamps,
     so it overlays the car's DC power on the same axis. None when unavailable.

--- a/web/templates/partials/charge_location.html
+++ b/web/templates/partials/charge_location.html
@@ -26,5 +26,24 @@
           style="background:none;border:none;cursor:pointer;padding:0;font-size:11px;line-height:1">
     <span class="htmx-indicator">⏳</span><span>🔄</span>
   </button>
+  {# #193: "Where to add stationname" — OSM/OCM simply don't have every real station, so
+     the lookup (🔄) can never fill it in on its own. A free-text fallback the user types
+     themselves. location_name IS NOT NULL either way, so this also takes the charge out
+     of the background sweep's queue, same as an auto-resolved name would. #}
+  <button type="button" title="{{ t('charger_locator_manual_hint') }}"
+          onclick="document.getElementById('loc-manual-{{ charge.id }}').classList.toggle('hidden')"
+          class="text-slate-500 hover:text-brand"
+          style="background:none;border:none;cursor:pointer;padding:0;font-size:11px;line-height:1">✏️</button>
+  <form id="loc-manual-{{ charge.id }}" class="hidden" style="display:flex;align-items:center;gap:4px"
+        hx-post="api/charges/{{ charge.id }}/locate/manual"
+        hx-target="#loc-{{ charge.id }}" hx-swap="outerHTML">
+    <input type="text" name="name" maxlength="200" placeholder="{{ t('charger_locator_manual_ph') }}"
+           value="{{ charge.location_name or '' }}"
+           style="width:140px;background:#0f172a;border:1px solid #334155;border-radius:6px;
+                  color:#e2e8f0;padding:2px 6px;font-size:11px">
+    <button type="submit" title="{{ t('note_save') }}"
+            class="text-slate-500 hover:text-brand"
+            style="background:none;border:none;cursor:pointer;padding:0;font-size:11px;line-height:1">✓</button>
+  </form>
   {% endif %}
 </div>


### PR DESCRIPTION

--
A ✏️ button next to the existing 🔄 recalculate button on a charge lets the user type a station name themselves. Answers #193 ("Where to add stationname"): the automatic lookup and the manual recalculate button both only ever query OpenStreetMap and Open Charge Map — if a real station simply isn't in either database, neither path can ever produce a name, and until now there was no third option.

No new column: it reuses set_charge_location_name(), the exact same write path the automatic sweep and the candidate-picker already use. A typed name is location_name IS NOT NULL either way, so it drops the charge out of the background sweep's queue (_LOCATION_CANDIDATES_WHERE) permanently, same as an auto-resolved name would — nothing extra needed to keep the sweep from re-touching it. The input opens pre-filled with whatever name is already there, so this doubles as a quick manual correction, not just a first-time entry. An empty submission changes nothing, matching the existing "don't wipe on an empty answer" rule the recalculate button already follows.

CRITICAL / trade-offs
- A hand-typed name is not specially protected from the recalculate button: if 🔄 is pressed later and the automatic lookup now finds EXACTLY ONE candidate (say OSM gains the node afterwards), it silently overwrites the manual name — no confirmation, no distinction from overwriting a previous auto-resolved name. This isn't a new problem introduced here; it's the same behavior the recalculate button already has for any existing name, just now also reachable by typing one yourself. Worth revisiting if it turns out to surprise anyone in practice.
- No visual marker distinguishes "auto-resolved from OSM/OCM" from "typed by hand" — both just show as a plain 📍 label. Deliberately kept simple for a first pass; easy to add a small indicator later if it turns out to matter (e.g. so a user knows whether re-running the lookup is likely to change anything).


--
Un pulsante ✏️ accanto al 🔄 di ricalcolo già esistente su una ricarica permette all'utente di digitare da sé il nome della colonnina. Risponde alla issue #193 ("Where to add stationname"): sia la ricerca automatica che il pulsante di ricalcolo manuale interrogano solo OpenStreetMap e Open Charge Map — se una colonnina reale semplicemente non è in nessuno dei due database, nessuno dei due percorsi può mai produrre un nome, e finora non esisteva una terza via.

Nessuna nuova colonna: riusa set_charge_location_name(), lo stesso identico percorso di scrittura già usato dallo sweep automatico e dal selettore dei candidati. Un nome digitato è comunque location_name IS NOT NULL, quindi fa uscire la ricarica dalla coda dello sweep in background (_LOCATION_CANDIDATES_WHERE) in modo permanente, esattamente come un nome auto-risolto — nessuna precauzione aggiuntiva necessaria per evitare che lo sweep lo tocchi di nuovo. Il campo si apre precompilato con il nome già presente, se c'è, quindi funziona anche come correzione rapida, non solo come primo inserimento. Un invio vuoto non cambia nulla, coerente con la regola già esistente "non cancellare su una risposta vuota" che il pulsante di ricalcolo già segue.

CRITICO / compromessi
- Un nome digitato a mano non è protetto in modo speciale dal pulsante di ricalcolo: se in seguito si preme di nuovo 🔄 e la ricerca automatica trova ora ESATTAMENTE un candidato (es. OSM acquisisce il nodo in seguito), sovrascrive silenziosamente il nome manuale — nessuna conferma, nessuna distinzione rispetto alla sovrascrittura di un precedente nome auto-risolto. Non è un problema nuovo introdotto qui: è lo stesso comportamento che il pulsante di ricalcolo ha già per qualsiasi nome esistente, solo ora raggiungibile anche digitandone uno da sé. Da rivalutare se in pratica dovesse sorprendere qualcuno.
- Nessun indicatore visivo distingue "risolto automaticamente da OSM/OCM" da "digitato a mano" — entrambi mostrano semplicemente un'etichetta 📍. Scelta deliberata di semplicità per una prima versione; facile aggiungere un piccolo indicatore in seguito se si rivelasse utile (es. per sapere se rilanciare la ricerca è probabile che cambi qualcosa).