### PR TITLE
Draw a real GPS signal-loss gap as a dashed bridge, not a straight line

### DIFF
--- a/tests/test_map_trip_count.py
+++ b/tests/test_map_trip_count.py
@@ -1,0 +1,146 @@
+"""The Map's "trips shown" box (get_all_track's max_trips) — same box-on-the-map,
+POST-Redirect-GET convention as the neighboring "stations shown" box (map_station_top_n,
+see test_trip_charges_and_map_count.py), extended to cap the number of trip ROUTES drawn.
+
+A long driving history otherwise leaves the whole map a solid mess of hundreds of overlapping
+lines — and since the point BUDGET (max_points) is shared across however many trips are drawn,
+capping the trip COUNT also gives each kept trip more of that budget, so its own line survives
+downsampling closer to the actually-driven road.
+"""
+import pytest
+
+import db as D
+import db_reader
+
+
+@pytest.fixture
+def env(tmp_path, monkeypatch):
+    path = str(tmp_path / "t.db")
+    pdb = D.Database(path)
+    monkeypatch.setattr(db_reader, "DB_PATH", path)
+    monkeypatch.setattr(db_reader, "get_language", lambda: "en")
+    return pdb
+
+
+def _trip_with_track(pdb, tid, started_at, pts):
+    pdb._conn.execute(
+        "INSERT INTO trips (id, vehicle_id, started_at, ended_at) VALUES (?,1,?,?)",
+        (tid, started_at, started_at))
+    pdb._conn.executemany(
+        "INSERT INTO trip_positions (trip_id, recorded_at, latitude, longitude) VALUES (?,?,?,?)",
+        [(tid, f"{started_at[:10]}T{10+i:02d}:00:00+00:00", lat, lon) for i, (lat, lon) in enumerate(pts)])
+    pdb._conn.commit()
+
+
+# ── get_all_track(max_trips=...) ───────────────────────────────────────────────
+
+def test_max_trips_keeps_only_the_most_recently_started(env):
+    pdb = env
+    _trip_with_track(pdb, 1, "2026-06-01T10:00:00+00:00", [(45.0, 9.0), (45.001, 9.001)])
+    _trip_with_track(pdb, 2, "2026-06-02T10:00:00+00:00", [(46.0, 9.0), (46.001, 9.001)])
+    _trip_with_track(pdb, 3, "2026-06-03T10:00:00+00:00", [(47.0, 9.0), (47.001, 9.001)])
+
+    tracks = db_reader.get_all_track(max_trips=2)
+    assert len(tracks) == 2
+    kept_lats = {tuple(run["points"][0]) for t in tracks for run in t}
+    assert (45.0, 9.0) not in kept_lats                  # the oldest trip, dropped
+    assert (46.0, 9.0) in kept_lats and (47.0, 9.0) in kept_lats
+
+
+def test_zero_or_none_means_every_trip(env):
+    pdb = env
+    for i in range(5):
+        _trip_with_track(pdb, i + 1, f"2026-06-0{i+1}T10:00:00+00:00", [(45.0 + i, 9.0), (45.0 + i, 9.001)])
+    assert len(db_reader.get_all_track(max_trips=0)) == 5
+    assert len(db_reader.get_all_track(max_trips=None)) == 5
+
+
+def test_max_trips_gives_each_kept_trip_more_of_the_point_budget(env):
+    """The whole reason to cap the trip COUNT rather than just the point budget: fewer trips
+    sharing the same max_points means each one keeps more points, not just fewer trips at the
+    same thinning ratio."""
+    pdb = env
+    for i in range(10):
+        pts = [(45.0 + i, 9.0 + j * 0.0001) for j in range(50)]
+        _trip_with_track(pdb, i + 1, f"2026-06-{10+i:02d}T10:00:00+00:00", pts)
+
+    all_tracks = db_reader.get_all_track(max_points=100, max_trips=None)
+    capped_tracks = db_reader.get_all_track(max_points=100, max_trips=2)
+    pts_per_trip_all = sum(len(run["points"]) for t in all_tracks for run in t) / len(all_tracks)
+    pts_per_trip_capped = sum(len(run["points"]) for t in capped_tracks for run in t) / len(capped_tracks)
+    assert pts_per_trip_capped > pts_per_trip_all
+
+
+# ── the Map's "trips shown" box (save_map_trip_count) ─────────────────────────
+
+class _Form:
+    def __init__(self, value):
+        self._v = value
+        self.headers = {}
+
+    async def form(self):
+        return {"trips": self._v}
+
+
+def _save(value):
+    import asyncio
+    import main
+    return asyncio.run(main.save_map_trip_count(_Form(value)))
+
+
+def test_the_trip_count_is_saved_and_redirects_back_to_the_map(env):
+    pytest.importorskip("fastapi", reason="web.main needs fastapi")
+    resp = _save("3")
+    assert db_reader.get_setting("map_trips_shown") == "3"
+    assert resp.status_code == 303                     # POST-Redirect-GET, not a re-postable page
+    assert resp.headers["location"].endswith("/map")
+
+
+def test_zero_means_all_of_them(env):
+    pytest.importorskip("fastapi", reason="web.main needs fastapi")
+    _save("0")
+    assert db_reader.get_setting("map_trips_shown") == "0"
+
+
+def test_a_hand_typed_number_is_clamped(env):
+    pytest.importorskip("fastapi", reason="web.main needs fastapi")
+    _save("999999999")
+    assert db_reader.get_setting("map_trips_shown") == "9999"
+    _save("-5")
+    assert db_reader.get_setting("map_trips_shown") == "0"
+
+
+def test_garbage_falls_back_to_zero_not_a_crash(env):
+    pytest.importorskip("fastapi", reason="web.main needs fastapi")
+    _save("abc")
+    assert db_reader.get_setting("map_trips_shown") == "0"
+
+
+def test_drawing_the_map_never_writes_the_trip_count_setting():
+    """Same convention as the station-count box: rendering must only READ. A bookmarked map
+    URL, a Back button, or a prefetch must never rewrite a stored preference as a side effect."""
+    pytest.importorskip("fastapi", reason="web.main needs fastapi")
+    import inspect
+
+    import main
+    src = inspect.getsource(main.map_page)
+    assert src.count("set_setting") == 0, "the map page writes a setting while rendering"
+    assert "trips" not in inspect.signature(main.map_page).parameters
+
+
+def test_the_new_strings_exist_in_every_locale():
+    import json
+    import pathlib
+    loc = pathlib.Path(__file__).resolve().parent.parent / "web" / "locales"
+    for lang in ("en", "it", "de", "fr", "pl", "pt-PT", "nl"):
+        d = json.loads((loc / f"{lang}.json").read_text(encoding="utf-8"))["translations"]
+        for key in ("map_trip_count_label", "map_trip_count_hint"):
+            assert key in d, f"{lang} is missing {key}"
+
+
+def test_the_trip_count_form_posts_rather_than_gets():
+    import pathlib
+    src = (pathlib.Path(__file__).resolve().parent.parent
+           / "web" / "templates" / "map.html").read_text()
+    form = src[src.index('<form', src.index("map_trip_count_label") - 400):]
+    assert 'method="post"' in form[:form.index(">") + 1]

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -139,7 +139,8 @@ def test_unconfirmed_excluded_from_split(tmp_path, monkeypatch):
 
 def test_month_track_filters_by_month(tmp_path, monkeypatch):
     """The month map shows only trips STARTED in the selected local month; each trip is its
-    own polyline, endpoints preserved, empty/bogus month → []."""
+    own track (one solid run — the fixture's points are 1 minute apart, well under the gap
+    threshold), endpoints preserved, empty/bogus month → []."""
     pdb = _setup(tmp_path, monkeypatch)
     _trip(pdb, 1, month="2026-05")
     _trip(pdb, 2, month="2026-06")
@@ -147,11 +148,13 @@ def test_month_track_filters_by_month(tmp_path, monkeypatch):
     _pos(pdb, 2, [(45.50, 9.20), (45.51, 9.21)])
 
     may = db_reader.get_month_track("2026-05")
-    assert len(may) == 1 and len(may[0]) == 3
-    assert may[0][0] == [45.4, 9.1] and may[0][-1] == [45.42, 9.12]
+    assert len(may) == 1 and len(may[0]) == 1            # one trip, one solid run (no gap)
+    assert may[0][0]["gap"] is False
+    assert may[0][0]["points"][0] == [45.4, 9.1] and may[0][0]["points"][-1] == [45.42, 9.12]
 
     jun = db_reader.get_month_track("2026-06")
-    assert len(jun) == 1 and len(jun[0]) == 2
+    assert len(jun) == 1 and len(jun[0]) == 1
+    assert len(jun[0][0]["points"]) == 2
 
     assert db_reader.get_month_track("2026-04") == []   # month with no trips
     assert db_reader.get_month_track("") == []          # guard

--- a/tests/test_track_gap_segments.py
+++ b/tests/test_track_gap_segments.py
@@ -62,16 +62,33 @@ def test_small_jump_at_fast_poll_rate_is_not_a_gap():
     assert len(segs) == 1 and segs[0]["gap"] is False
 
 
-def test_absolute_floor_flags_a_relatively_small_but_real_gap():
-    """At a very fast poll rate (2s), a 90s hole is "only" 45x the median — clearly a gap by the
-    multiplier alone, but the point of the _TRACK_GAP_MIN_S floor is that even a SMALLER relative
-    jump still gets flagged once it crosses an absolute minute, so a fast-polling trip can't have
-    a real dropout hidden by its own tight cadence."""
+def test_a_fast_poll_rate_still_flags_a_gap_over_a_minute():
+    """At a very fast poll rate (2s) a 65s hole clears both tests — 32x the median AND over the
+    absolute floor — so it is a gap. (This case does NOT exercise the floor: see the test below,
+    which is the one that does.)"""
     base = datetime(2026, 7, 18, 10, 0, tzinfo=timezone.utc)
     before = [_pt(_secs(base, i * 2), 45.0, 9.0) for i in range(5)]
     after = [_pt(_secs(base, 8 + 65), 45.01, 9.01)]   # 65s gap: > _TRACK_GAP_MIN_S (60s)
     segs = DR._split_track_gaps(before + after)
     assert [s["gap"] for s in segs] == [False, True]
+
+
+def test_the_floor_keeps_a_sub_minute_jump_at_a_fast_poll_rate_solid():
+    """THE FLOOR'S OWN CASE, and the only one that fails if _TRACK_GAP_MIN_S is removed.
+
+    The floor RAISES the threshold, so it makes detection less eager, not more: on a 2s cadence
+    the multiplier alone would call anything past 6s a signal loss, and a car that simply misses
+    a handful of polls in traffic would sprout dashed bridges all over an ordinary drive. A 30s
+    jump is 15x the median — well past the multiplier — and must still draw SOLID, because a
+    minute is the point below which we are not willing to claim the signal was lost.
+
+    Written by the maintainers on top of #209: the suite passed unchanged with the floor set to
+    zero, so nothing was holding this behaviour in place."""
+    base = datetime(2026, 7, 18, 10, 0, tzinfo=timezone.utc)
+    rows = [_pt(_secs(base, i * 2), 45.0, 9.0) for i in range(5)] + \
+           [_pt(_secs(base, 8 + 30), 45.01, 9.01)]      # 30s: past median x3 (6s), under the 60s floor
+    segs = DR._split_track_gaps(rows)
+    assert [s["gap"] for s in segs] == [False], "a sub-minute jump must not be called a signal loss"
 
 
 def test_empty_and_single_point_do_not_crash():

--- a/tests/test_track_gap_segments.py
+++ b/tests/test_track_gap_segments.py
@@ -1,0 +1,153 @@
+"""Gap-aware map tracks (_split_track_gaps / _rows_to_segments).
+
+The Map, the report's month map, and a single trip's own map used to draw one straight polyline
+through every recorded point — including across a real signal-loss stretch (tunnel, dead zone, a
+cloud hiccup), where the resulting straight line cuts through buildings/fields instead of
+following the road the car was actually on. There's no way to tell "the car really drove this
+straight line" from "we lost the signal here" once they're rendered identically.
+
+_split_track_gaps marks the difference: a jump much bigger than the trip's own typical sampling
+interval becomes its own 2-point "gap" segment (drawn dashed by the templates), while normal
+consecutive samples stay a single solid run (drawn as the actually-recorded path). The threshold
+is RELATIVE (median inter-sample delay × a multiplier, floored at a minute) so it self-adjusts to
+whatever driving poll interval is configured, instead of assuming a fixed cadence.
+"""
+from datetime import datetime, timedelta, timezone
+
+import db as D
+import db_reader as DR
+
+
+def _pt(t, lat, lon):
+    return {"recorded_at": t.isoformat(), "latitude": lat, "longitude": lon}
+
+
+def _secs(base, s):
+    return base + timedelta(seconds=s)
+
+
+def test_normal_driving_is_one_solid_run():
+    """Points 10s apart (the default driving poll) — no gap, one run covering everything."""
+    base = datetime(2026, 7, 18, 10, 0, tzinfo=timezone.utc)
+    pts = [_pt(_secs(base, i * 10), 45.0 + i * 0.001, 9.0) for i in range(10)]
+    segs = DR._split_track_gaps(pts)
+    assert len(segs) == 1
+    assert segs[0]["gap"] is False
+    assert len(segs[0]["points"]) == 10
+
+
+def test_real_gap_becomes_a_bridge_segment():
+    """A 10-minute hole in an otherwise 10s-cadence trip — e.g. a tunnel — must split into
+    [solid run before, 2-point gap bridge, solid run after], not one uninterrupted solid line."""
+    base = datetime(2026, 7, 18, 10, 0, tzinfo=timezone.utc)
+    before = [_pt(_secs(base, i * 10), 45.0 + i * 0.001, 9.0) for i in range(5)]
+    after_start = _secs(base, 40 + 600)   # 10 real minutes after the last "before" sample
+    after = [_pt(_secs(after_start, i * 10), 45.1 + i * 0.001, 9.1) for i in range(5)]
+    segs = DR._split_track_gaps(before + after)
+
+    assert [s["gap"] for s in segs] == [False, True, False]
+    assert len(segs[0]["points"]) == 5
+    assert len(segs[2]["points"]) == 5
+    # The bridge is exactly the two real endpoints straddling the hole — nothing invented.
+    assert segs[1]["points"] == [segs[0]["points"][-1], segs[2]["points"][0]]
+
+
+def test_small_jump_at_fast_poll_rate_is_not_a_gap():
+    """A 2-minute jump would be "3x the median" if the median were 10s (2 min = 12x — actually
+    IS a gap there), but at a SLOWER configured poll rate (e.g. 90s) the same absolute jump is
+    normal cadence and must not be flagged — the threshold is relative to the trip's own rate."""
+    base = datetime(2026, 7, 18, 10, 0, tzinfo=timezone.utc)
+    pts = [_pt(_secs(base, i * 90), 45.0 + i * 0.001, 9.0) for i in range(6)]
+    segs = DR._split_track_gaps(pts)
+    assert len(segs) == 1 and segs[0]["gap"] is False
+
+
+def test_absolute_floor_flags_a_relatively_small_but_real_gap():
+    """At a very fast poll rate (2s), a 90s hole is "only" 45x the median — clearly a gap by the
+    multiplier alone, but the point of the _TRACK_GAP_MIN_S floor is that even a SMALLER relative
+    jump still gets flagged once it crosses an absolute minute, so a fast-polling trip can't have
+    a real dropout hidden by its own tight cadence."""
+    base = datetime(2026, 7, 18, 10, 0, tzinfo=timezone.utc)
+    before = [_pt(_secs(base, i * 2), 45.0, 9.0) for i in range(5)]
+    after = [_pt(_secs(base, 8 + 65), 45.01, 9.01)]   # 65s gap: > _TRACK_GAP_MIN_S (60s)
+    segs = DR._split_track_gaps(before + after)
+    assert [s["gap"] for s in segs] == [False, True]
+
+
+def test_empty_and_single_point_do_not_crash():
+    assert DR._split_track_gaps([]) == []
+    one = [_pt(datetime(2026, 7, 18, 10, 0, tzinfo=timezone.utc), 45.0, 9.0)]
+    segs = DR._split_track_gaps(one)
+    assert len(segs) == 1 and segs[0]["points"] == [[45.0, 9.0]]
+
+
+def test_accepts_sqlite_row_not_just_dict():
+    """get_all_track/get_month_track pass raw sqlite3.Row objects (never dict-ified) — Row
+    supports r["col"] but not r.get(), so the gap detector must use indexing, not .get()."""
+    import sqlite3
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute("CREATE TABLE t (recorded_at TEXT, latitude REAL, longitude REAL)")
+    conn.executemany("INSERT INTO t VALUES (?,?,?)", [
+        ("2026-07-18T10:00:00+00:00", 45.0, 9.0),
+        ("2026-07-18T10:00:10+00:00", 45.001, 9.0),
+    ])
+    rows = conn.execute("SELECT * FROM t").fetchall()
+    segs = DR._split_track_gaps(rows)
+    assert len(segs) == 1 and segs[0]["gap"] is False
+
+
+def _setup(tmp_path, monkeypatch):
+    pdb = D.Database(str(tmp_path / "t.db"))
+    monkeypatch.setattr(DR, "DB_PATH", str(tmp_path / "t.db"))
+    return pdb
+
+
+def test_get_all_track_marks_a_real_gap_end_to_end(tmp_path, monkeypatch):
+    """Through the real DB path (get_all_track), not just the unit-level helper: a trip with a
+    genuine mid-trip signal-loss gap comes back as solid/gap/solid, matching what the Map now
+    renders as a dashed bridge."""
+    pdb = _setup(tmp_path, monkeypatch)
+    pdb._conn.execute(
+        "INSERT INTO trips (id, vehicle_id, started_at, ended_at, distance_km)"
+        " VALUES (1,1,'2026-07-18T10:00:00+00:00','2026-07-18T10:20:00+00:00',5.0)")
+    rows = [
+        (1, "2026-07-18T10:00:00+00:00", 45.40, 9.10),
+        (1, "2026-07-18T10:00:10+00:00", 45.401, 9.101),
+        (1, "2026-07-18T10:00:20+00:00", 45.402, 9.102),
+        # a 12-minute tunnel/dead-zone hole
+        (1, "2026-07-18T10:12:20+00:00", 45.500, 9.200),
+        (1, "2026-07-18T10:12:30+00:00", 45.501, 9.201),
+    ]
+    pdb._conn.executemany(
+        "INSERT INTO trip_positions (trip_id, recorded_at, latitude, longitude) VALUES (?,?,?,?)", rows)
+    pdb._conn.commit()
+
+    tracks = DR.get_all_track()
+    assert len(tracks) == 1
+    runs = tracks[0]
+    assert [r["gap"] for r in runs] == [False, True, False]
+    assert len(runs[0]["points"]) == 3 and len(runs[2]["points"]) == 2
+
+
+def test_downsampling_never_thins_a_gap_bridge(tmp_path, monkeypatch):
+    """max_points forces heavy downsampling of the solid runs, but a gap bridge is already just
+    its 2 endpoints and must survive untouched — thinning it would risk losing the one honest
+    signal (a dashed line) that a stretch wasn't really measured."""
+    pdb = _setup(tmp_path, monkeypatch)
+    pdb._conn.execute(
+        "INSERT INTO trips (id, vehicle_id, started_at, ended_at, distance_km)"
+        " VALUES (1,1,'2026-07-18T10:00:00+00:00','2026-07-18T11:00:00+00:00',50.0)")
+    rows = [(1, f"2026-07-18T10:{i:02d}:00+00:00", 45.0 + i * 0.001, 9.0) for i in range(40)]
+    # a 20-minute gap right after the 40 close-together samples
+    rows.append((1, "2026-07-18T11:00:00+00:00", 45.5, 9.5))
+    pdb._conn.executemany(
+        "INSERT INTO trip_positions (trip_id, recorded_at, latitude, longitude) VALUES (?,?,?,?)", rows)
+    pdb._conn.commit()
+
+    tracks = DR.get_all_track(max_points=10)   # force heavy downsampling
+    runs = tracks[0]
+    assert runs[-1]["gap"] is True
+    assert len(runs[-1]["points"]) == 2                  # never thinned
+    assert len(runs[0]["points"]) < 40                   # the solid run WAS downsampled
+    assert runs[0]["points"][0] == [45.0, 9.0]            # real first point kept

--- a/tests/test_vehicle_scoping.py
+++ b/tests/test_vehicle_scoping.py
@@ -117,7 +117,8 @@ def _two_car_db_with_tracks(tmp_path, monkeypatch):
 def test_get_all_track_scoped_to_current(tmp_path, monkeypatch):
     """trip_positions class — scoped via `trip_id IN (SELECT id FROM trips WHERE vehicle_id=...)`."""
     _two_car_db_with_tracks(tmp_path, monkeypatch)
-    pts = [p for seg in db_reader.get_all_track() for p in seg]   # flatten polylines → [lat,lon] pts
+    # flatten tracks → runs → [lat,lon] pts
+    pts = [p for track in db_reader.get_all_track() for run in track for p in run["points"]]
     assert pts and all(lat > 44 for lat, lon in pts)     # only Milan (v1), never Rome (v2, lat ~41.9)
 
 

--- a/web/db_reader.py
+++ b/web/db_reader.py
@@ -3921,7 +3921,14 @@ def get_trip_detail(trip_id: int) -> Optional[dict]:
     # elevation_m is only fetched for the DOWNSAMPLED subset the sweep queried Open-Meteo for — fill
     # the rest by interpolation so the chart draws a smooth line, not one broken at every un-sampled point.
     positions = _interpolate_elevation(positions)
+    # Same solid/gap-bridge split the global Map and the report's month map use (see
+    # _split_track_gaps) — a real signal-loss stretch draws dashed instead of as a solid line
+    # implying an actually-driven straight path. Kept SEPARATE from `positions` itself: the
+    # SoC/speed chart below indexes `positions` 1:1 by position, and rounding/regrouping it here
+    # would break that alignment.
+    route_segments = _split_track_gaps(positions)
     trip_d = _trip_group_stats(dict(trip), children)
+    trip_d["route_segments"] = route_segments
     trip_d["elevation_profile_available"] = elevation_profile_available
     if trip_d.get("is_merged"):
         elapsed = _gap_minutes(trip_d.get("started_at"), trip_d.get("ended_at"))
@@ -5917,57 +5924,129 @@ def get_v2l_total_kwh() -> float:
 
 # ── Global map (all tracks + frequent places) ──────────────────────────────────
 
-def _rows_to_segments(rows, max_points: int) -> list[list[list[float]]]:
-    """Group ordered (trip_id, lat, lon) rows into one polyline per trip (never joined across
-    trips), then proportionally downsample to ~max_points total while keeping each trip's real
-    first/last point. Shared by the global map (get_all_track) and the report's month map."""
-    segments: list[list[list[float]]] = []
-    cur_id, cur = None, []
+_TRACK_GAP_MULTIPLIER = 3.0   # a jump this many times the trip's own median sample interval...
+_TRACK_GAP_MIN_S = 60         # ...but never under a minute — keeps normal jitter at a fast
+                              # poll rate from being mistaken for a real signal loss
+
+
+def _split_track_gaps(rows: list[dict]) -> list[dict]:
+    """One trip's time-ordered GPS rows → alternating solid/gap segments, so a real signal-loss
+    stretch (tunnel, dead zone, a cloud hiccup) draws as a short dashed bridge instead of a solid
+    line implying an actually-driven straight path — same treatment the trip-profile chart
+    already gives a gap in SoC/speed (blank rather than joined). The threshold is relative to
+    THIS trip's own typical sampling interval (median inter-sample delay × _TRACK_GAP_MULTIPLIER,
+    floored at _TRACK_GAP_MIN_S), so it self-adjusts to whatever driving poll interval is
+    configured instead of a hardcoded cadence.
+
+    Each dict is {"points": [[lat,lon], ...], "gap": bool}; a gap segment is always exactly its
+    two bounding (last-known, first-resumed) points. rows must be pre-sorted chronologically."""
+    n = len(rows)
+    if n == 0:
+        return []
+    if n < 2:
+        return [{"points": [[round(rows[0]["latitude"], 5), round(rows[0]["longitude"], 5)]], "gap": False}]
+
+    def pt(r):
+        return [round(r["latitude"], 5), round(r["longitude"], 5)]
+
+    times = [_trip_epoch(r["recorded_at"]) for r in rows]
+    deltas = sorted(times[i] - times[i - 1] for i in range(1, n)
+                    if times[i] is not None and times[i - 1] is not None and times[i] > times[i - 1])
+    threshold = max(deltas[len(deltas) // 2] * _TRACK_GAP_MULTIPLIER, _TRACK_GAP_MIN_S) if deltas else _TRACK_GAP_MIN_S
+
+    segments = []
+    run = [rows[0]]
+    for i in range(1, n):
+        t0, t1 = times[i - 1], times[i]
+        if t0 is not None and t1 is not None and (t1 - t0) > threshold:
+            if len(run) >= 2:
+                segments.append({"points": [pt(r) for r in run], "gap": False})
+            segments.append({"points": [pt(rows[i - 1]), pt(rows[i])], "gap": True})
+            run = [rows[i]]
+        else:
+            run.append(rows[i])
+    if len(run) >= 2:
+        segments.append({"points": [pt(r) for r in run], "gap": False})
+    return segments
+
+
+def _downsample_points(pts: list, keep: int) -> list:
+    """Evenly reduce a plain [lat,lon] list to ``keep`` points, always ending on the real last
+    point — the same index math _rows_to_segments has always used, factored out so it can be
+    applied per solid RUN now instead of once per whole trip."""
+    if keep >= len(pts):
+        return pts
+    st = len(pts) / keep
+    ds = [pts[int(i * st)] for i in range(keep)]
+    ds[-1] = pts[-1]
+    return ds
+
+
+def _rows_to_segments(rows, max_points: int) -> list[list[dict]]:
+    """Group ordered (trip_id, lat, lon, recorded_at) rows into one track per trip (never joined
+    across trips), each track split into alternating solid/gap-bridge segments (see
+    _split_track_gaps). Solid runs are proportionally downsampled to ~max_points total (summed
+    across every trip) while keeping each run's real first/last point; gap bridges are already
+    just their 2 endpoints and are never thinned further. Shared by the global map
+    (get_all_track) and the report's month map."""
+    tracks: list[list[dict]] = []
+    cur_id, cur_rows = None, []
     for r in rows:
         if r["trip_id"] != cur_id:
-            if len(cur) >= 2:
-                segments.append(cur)
-            cur, cur_id = [], r["trip_id"]
-        cur.append([round(r["latitude"], 5), round(r["longitude"], 5)])
-    if len(cur) >= 2:
-        segments.append(cur)
+            if len(cur_rows) >= 2:
+                tracks.append(_split_track_gaps(cur_rows))
+            cur_rows, cur_id = [], r["trip_id"]
+        cur_rows.append(r)
+    if len(cur_rows) >= 2:
+        tracks.append(_split_track_gaps(cur_rows))
 
-    total = sum(len(s) for s in segments)
+    total = sum(len(seg["points"]) for t in tracks for seg in t if not seg["gap"])
     if total <= max_points or total == 0:
-        return segments
-    # Proportional per-trip downsample, keeping each segment's real endpoints.
+        return tracks
     step = total / max_points
     out = []
-    for s in segments:
-        keep = max(2, int(len(s) / step))
-        if keep >= len(s):
-            out.append(s)
-            continue
-        st = len(s) / keep
-        ds = [s[int(i * st)] for i in range(keep)]
-        ds[-1] = s[-1]
-        out.append(ds)
+    for t in tracks:
+        new_t = []
+        for seg in t:
+            if seg["gap"]:
+                new_t.append(seg)
+                continue
+            keep = max(2, int(len(seg["points"]) / step))
+            new_t.append({"points": _downsample_points(seg["points"], keep), "gap": False})
+        out.append(new_t)
     return out
 
 
-def get_all_track(max_points: int = 12000) -> list[list[list[float]]]:
-    """Every trip's GPS track as a list of polylines (one [lat, lon] list per trip),
-    so the global map draws the actual driven roads as connected lines instead of
-    loose dots. Points are NEVER joined across trips. Downsampled to roughly
-    ``max_points`` total while always keeping each trip's first and last point, so the
-    lines stay continuous even when zoomed in."""
+def get_all_track(max_points: int = 12000, max_trips: Optional[int] = None) -> list[list[dict]]:
+    """Every trip's GPS track as a list of tracks (one per trip, never joined across trips),
+    each itself a list of {"points": [[lat,lon],...], "gap": bool} segments — so the global map
+    draws the actual driven roads as connected lines, with a real signal-loss stretch shown as a
+    dashed bridge (_split_track_gaps) instead of a solid line implying an actually-driven path.
+    Downsampled to roughly ``max_points`` total while always keeping each run's first and last
+    point, so the lines stay continuous even when zoomed in.
+
+    `max_trips` (None/0 = every trip) caps the map to the N most recently STARTED trips — a long
+    driving history otherwise leaves the whole map a solid mess of hundreds of overlapping lines.
+    Capping the trip COUNT (not just the point budget) also means the SAME max_points is spent on
+    fewer trips, so each kept trip's own line stays closer to the actually-driven road instead of
+    being thinned into long chords by a budget split hundreds of ways."""
     db = _get()
+    trip_filter = "SELECT id FROM trips WHERE vehicle_id = COALESCE(?, vehicle_id)"
+    params: list = [_current_vehicle_id()]
+    if max_trips:
+        trip_filter += " ORDER BY started_at DESC LIMIT ?"
+        params.append(max_trips)
     rows = db.execute(
-        "SELECT trip_id, latitude, longitude FROM trip_positions "
-        "WHERE trip_id IN (SELECT id FROM trips WHERE vehicle_id = COALESCE(?, vehicle_id)) "
+        f"SELECT trip_id, latitude, longitude, recorded_at FROM trip_positions "
+        f"WHERE trip_id IN ({trip_filter}) "
         "AND latitude IS NOT NULL AND longitude IS NOT NULL ORDER BY trip_id, id",
-        (_current_vehicle_id(),)
+        params
     ).fetchall()
     return _rows_to_segments(rows, max_points)
 
 
-def get_month_track(month: str, max_points: int = 8000) -> list[list[list[float]]]:
-    """GPS polylines for every trip STARTED in the given local 'YYYY-MM' — the report's month
+def get_month_track(month: str, max_points: int = 8000) -> list[list[dict]]:
+    """GPS tracks for every trip STARTED in the given local 'YYYY-MM' — the report's month
     map. Same shape/downsampling as get_all_track, scoped to one month's trips (parent and
     merged-child trips alike, so every road driven that month is drawn)."""
     if not month:
@@ -5983,7 +6062,7 @@ def get_month_track(month: str, max_points: int = 8000) -> list[list[list[float]
         return []
     ph = ",".join("?" * len(ids))
     rows = db.execute(
-        "SELECT trip_id, latitude, longitude FROM trip_positions "
+        "SELECT trip_id, latitude, longitude, recorded_at FROM trip_positions "
         f"WHERE trip_id IN ({ph}) AND latitude IS NOT NULL AND longitude IS NOT NULL "
         "ORDER BY trip_id, id", ids
     ).fetchall()

--- a/web/locales/de.json
+++ b/web/locales/de.json
@@ -196,6 +196,8 @@
     "map_station_threshold_saved": "Schwelle gespeichert",
     "map_station_count_label": "Angezeigte Stationen",
     "map_station_count_hint": "Maximale Anzahl an Ladestationen-Markern auf der Karte (0 = alle anzeigen).",
+    "map_trip_count_label": "Angezeigte Fahrten",
+    "map_trip_count_hint": "Maximale Anzahl der zuletzt gefahrenen Fahrten, die auf der Karte angezeigt werden (0 = alle anzeigen).",
     "charger_locator_relocate_hint": "Ladestation dieser Ladung neu berechnen",
     "charger_locator_relocate_confirm": "Ladestation dieser Ladung neu berechnen?",
     "charger_locator_relocate_error": "Suche fehlgeschlagen — später erneut versuchen",

--- a/web/locales/en.json
+++ b/web/locales/en.json
@@ -196,6 +196,8 @@
     "map_station_threshold_saved": "Threshold saved",
     "map_station_count_label": "Stations shown",
     "map_station_count_hint": "Maximum number of charging-station markers shown on the map (0 = show them all).",
+    "map_trip_count_label": "Trips shown",
+    "map_trip_count_hint": "Maximum number of most-recently-driven trips shown on the map (0 = show them all).",
     "charger_locator_relocate_hint": "Recalculate this charge's station",
     "charger_locator_relocate_confirm": "Recalculate this charge's station?",
     "charger_locator_relocate_error": "Lookup failed — try again later",

--- a/web/locales/fr.json
+++ b/web/locales/fr.json
@@ -196,6 +196,8 @@
     "map_station_threshold_saved": "Seuil enregistré",
     "map_station_count_label": "Bornes affichées",
     "map_station_count_hint": "Nombre maximum de marqueurs de bornes de recharge affichés sur la carte (0 = toutes les afficher).",
+    "map_trip_count_label": "Trajets affichés",
+    "map_trip_count_hint": "Nombre maximum des trajets les plus récents affichés sur la carte (0 = tous les afficher).",
     "charger_locator_relocate_hint": "Recalculer la borne de cette recharge",
     "charger_locator_relocate_confirm": "Recalculer la borne de cette recharge ?",
     "charger_locator_relocate_error": "Échec de la recherche — réessayez plus tard",

--- a/web/locales/it.json
+++ b/web/locales/it.json
@@ -196,6 +196,8 @@
     "map_station_threshold_saved": "Soglia salvata",
     "map_station_count_label": "Colonnine mostrate",
     "map_station_count_hint": "Numero massimo di colonnine mostrate sulla mappa (0 = mostrale tutte).",
+    "map_trip_count_label": "Viaggi mostrati",
+    "map_trip_count_hint": "Numero massimo di viaggi più recenti mostrati sulla mappa (0 = mostrali tutti).",
     "charger_locator_relocate_hint": "Ricalcola la colonnina di questa ricarica",
     "charger_locator_relocate_confirm": "Ricalcolare la colonnina di questa ricarica?",
     "charger_locator_relocate_error": "Ricerca non riuscita — riprova più tardi",

--- a/web/locales/nl.json
+++ b/web/locales/nl.json
@@ -196,6 +196,8 @@
     "map_station_threshold_saved": "Drempel opgeslagen",
     "map_station_count_label": "Getoonde laadpalen",
     "map_station_count_hint": "Maximum aantal laadpaalmarkers dat op de kaart getoond wordt (0 = allemaal tonen).",
+    "map_trip_count_label": "Getoonde ritten",
+    "map_trip_count_hint": "Maximum aantal meest recente ritten dat op de kaart getoond wordt (0 = allemaal tonen).",
     "charger_locator_relocate_hint": "De laadpaal van deze laadbeurt opnieuw bepalen",
     "charger_locator_relocate_confirm": "De laadpaal van deze laadbeurt opnieuw bepalen?",
     "charger_locator_relocate_error": "Opzoeken mislukt — probeer het later opnieuw",

--- a/web/locales/pl.json
+++ b/web/locales/pl.json
@@ -196,6 +196,8 @@
     "map_station_threshold_saved": "Próg zapisany",
     "map_station_count_label": "Wyświetlane stacje",
     "map_station_count_hint": "Maksymalna liczba znaczników stacji ładowania wyświetlanych na mapie (0 = pokaż wszystkie).",
+    "map_trip_count_label": "Wyświetlane trasy",
+    "map_trip_count_hint": "Maksymalna liczba najnowszych tras wyświetlanych na mapie (0 = pokaż wszystkie).",
     "charger_locator_relocate_hint": "Przelicz stację dla tego ładowania",
     "charger_locator_relocate_confirm": "Przeliczyć stację dla tego ładowania?",
     "charger_locator_relocate_error": "Wyszukiwanie nie powiodło się — spróbuj później",

--- a/web/locales/pt-PT.json
+++ b/web/locales/pt-PT.json
@@ -196,6 +196,8 @@
     "map_station_threshold_saved": "Limite guardado",
     "map_station_count_label": "Estações mostradas",
     "map_station_count_hint": "Número máximo de marcadores de estações de carregamento mostrados no mapa (0 = mostrar todas).",
+    "map_trip_count_label": "Viagens mostradas",
+    "map_trip_count_hint": "Número máximo das viagens mais recentes mostradas no mapa (0 = mostrar todas).",
     "charger_locator_relocate_hint": "Recalcular a estação desta carga",
     "charger_locator_relocate_confirm": "Recalcular a estação desta carga?",
     "charger_locator_relocate_error": "Pesquisa falhou — tente novamente mais tarde",

--- a/web/main.py
+++ b/web/main.py
@@ -1484,7 +1484,14 @@ async def maintenance_baseline(request: Request):
 @app.get("/map", response_class=HTMLResponse)
 async def map_page(request: Request):
     vehicle, _ = db_reader.get_vehicle()
-    track    = db_reader.get_all_track()
+    # How many trip routes to draw (get_all_track's max_trips), set from the box on the map's own
+    # legend row — same POST-Redirect-GET convention as the station-count box (save_map_trip_count
+    # below): 0 = every trip, the pre-existing behavior, so a fresh install is unaffected.
+    try:
+        trips_shown = max(0, int(db_reader.get_setting("map_trips_shown", "0")))
+    except (TypeError, ValueError):
+        trips_shown = 0
+    track    = db_reader.get_all_track(max_trips=trips_shown or None)
     places   = db_reader.get_frequent_places()
     # Default 1, deliberately: a station used ONCE is exactly what this layer is for (see
     # get_charging_stations). The slider exists for the opposite taste — someone who charges
@@ -1512,7 +1519,7 @@ async def map_page(request: Request):
             c["cost_fmt"] = _money(c["cost"]) if c["cost"] is not None else None
     return templates.TemplateResponse(request, "map.html", _ctx(
         page="map", vehicle=vehicle, track=track, places=places, stations=stations,
-        stations_top_n=stations_top_n,
+        stations_top_n=stations_top_n, trips_shown=trips_shown,
     ))
 
 
@@ -3030,6 +3037,21 @@ async def save_map_station_count(request: Request):
     except (TypeError, ValueError):
         n = 15
     db_reader.set_setting("map_station_top_n", str(n))
+    return RedirectResponse(request.headers.get("x-ingress-path", "") + "/map", status_code=303)
+
+
+@app.post("/api/settings/map-trip-count")
+async def save_map_trip_count(request: Request):
+    """How many trip routes the Map draws (get_all_track's max_trips, the N most recently
+    STARTED trips); 0 = every trip. Same box-on-the-map / POST-Redirect-GET convention as
+    save_map_station_count above, and the same reason: a GET that writes a stored preference
+    would be re-applied by a bookmark, Back, or link prefetch."""
+    form = await request.form()
+    try:
+        n = max(0, min(9999, int(form.get("trips") or 0)))
+    except (TypeError, ValueError):
+        n = 0
+    db_reader.set_setting("map_trips_shown", str(n))
     return RedirectResponse(request.headers.get("x-ingress-path", "") + "/map", status_code=303)
 
 

--- a/web/templates/map.html
+++ b/web/templates/map.html
@@ -18,9 +18,9 @@
     const places   = {{ places | tojson }};
     const stations = {{ stations | tojson }};
 
-    // All points (across every segment) just to frame the map.
+    // All points (across every run, solid or gap-bridge) just to frame the map.
     const allPts = [];
-    segments.forEach(function (s) { s.forEach(function (p) { allPts.push(p); }); });
+    segments.forEach(function (trip) { trip.forEach(function (run) { run.points.forEach(function (p) { allPts.push(p); }); }); });
 
     const map = L.map('map', { preferCanvas: true }).fitBounds(L.latLngBounds(allPts).pad(0.05));
     L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
@@ -33,10 +33,21 @@
 
     // Each trip as its own connected polyline — never joined across trips. A white
     // casing under a blue line keeps the route legible over any road colour (OSM
-    // motorways/primaries are red/orange/yellow, so a plain red line blended in).
-    segments.forEach(function (s) {
-      L.polyline(s, { color: '#ffffff', weight: 5,   opacity: 0.7, lineJoin: 'round', lineCap: 'round' }).addTo(map);
-      L.polyline(s, { color: '#2563eb', weight: 2.5, opacity: 0.9, lineJoin: 'round', lineCap: 'round' }).addTo(map);
+    // motorways/primaries are red/orange/yellow, so a plain red line blended in). A
+    // gap-bridge run (real signal loss — see db_reader._split_track_gaps) gets its own white
+    // casing too, then a bold magenta dash on top — a colour used nowhere else on this map
+    // (not the route blue, not OSM's own grey/brown dashed tracks and borders), with dashes
+    // wide enough to read as a deliberate marking instead of blending into the base tiles.
+    segments.forEach(function (trip) {
+      trip.forEach(function (run) {
+        if (run.gap) {
+          L.polyline(run.points, { color: '#ffffff', weight: 5, opacity: 0.6, lineCap: 'round' }).addTo(map);
+          L.polyline(run.points, { color: '#ec4899', weight: 3, opacity: 0.95, dashArray: '10,8', lineCap: 'round' }).addTo(map);
+        } else {
+          L.polyline(run.points, { color: '#ffffff', weight: 5,   opacity: 0.7, lineJoin: 'round', lineCap: 'round' }).addTo(map);
+          L.polyline(run.points, { color: '#2563eb', weight: 2.5, opacity: 0.9, lineJoin: 'round', lineCap: 'round' }).addTo(map);
+        }
+      });
     });
 
     // Frequent places: bubble sized by visit count, on top of the routes.
@@ -93,9 +104,18 @@
   {% if places %}<span><span style="color:#14b8a6">●</span> {{ t('map_frequent_places') }} ({{ places|length }})</span>{% endif %}
   {% if stations %}<span><span style="color:#f59e0b">●</span> {{ t('map_charging_stations') }} ({{ stations|length }})</span>{% endif %}
   <span><span id="map-pts">—</span> {{ t('map_points') }}</span>
-  {# POSTs and comes back through a redirect — see save_map_station_count: a GET here would
-     re-save the preference every time someone hit Back or opened a bookmarked map URL. #}
-  <form method="post" action="api/settings/map-station-count" class="ml-auto flex items-center gap-1.5">
+  {# Both POST and come back through a redirect — see save_map_trip_count/save_map_station_count:
+     a GET here would re-save the preference every time someone hit Back or opened a bookmarked
+     map URL. #}
+  <form method="post" action="api/settings/map-trip-count" class="ml-auto flex items-center gap-1.5">
+    <label for="map-trip-n">{{ t('map_trip_count_label') }}</label>
+    <input id="map-trip-n" type="number" name="trips" min="0" step="1" inputmode="numeric"
+           value="{{ trips_shown }}" title="{{ t('map_trip_count_hint') }}"
+           onchange="this.value = this.value === '' ? 0 : this.value; this.form.submit()"
+           style="width:52px;background:#0f172a;border:1px solid #334155;border-radius:6px;
+                  color:#e2e8f0;padding:2px 6px;font-size:11px">
+  </form>
+  <form method="post" action="api/settings/map-station-count" class="flex items-center gap-1.5">
     <label for="map-top-n">{{ t('map_station_count_label') }}</label>
     <input id="map-top-n" type="number" name="top_n" min="0" step="1" inputmode="numeric"
            value="{{ stations_top_n }}" title="{{ t('map_station_count_hint') }}"

--- a/web/templates/report.html
+++ b/web/templates/report.html
@@ -261,17 +261,28 @@
   (function () {
     const segments = {{ track | tojson }};
     const allPts = [];
-    segments.forEach(function (s) { s.forEach(function (p) { allPts.push(p); }); });
+    segments.forEach(function (trip) { trip.forEach(function (run) { run.points.forEach(function (p) { allPts.push(p); }); }); });
     if (!allPts.length) return;
     const map = L.map('report-map', { preferCanvas: true }).fitBounds(L.latLngBounds(allPts).pad(0.05));
     L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
       attribution: '© OpenStreetMap',
       referrerPolicy: 'origin'   // keep OSM tiles loading under Firefox strict tracking protection
     }).addTo(map);
-    // White casing under a blue line so each route stays legible over any road colour.
-    segments.forEach(function (s) {
-      L.polyline(s, { color: '#ffffff', weight: 5,   opacity: 0.7, lineJoin: 'round', lineCap: 'round' }).addTo(map);
-      L.polyline(s, { color: '#2563eb', weight: 2.5, opacity: 0.9, lineJoin: 'round', lineCap: 'round' }).addTo(map);
+    // White casing under a blue line so each route stays legible over any road colour. A
+    // gap-bridge run (real signal loss — see db_reader._split_track_gaps) gets its own white
+    // casing too, then a bold magenta dash on top — a colour used nowhere else on this map
+    // (not the route blue, not OSM's own grey/brown dashed tracks and borders), with dashes
+    // wide enough to read as a deliberate marking instead of blending into the base tiles.
+    segments.forEach(function (trip) {
+      trip.forEach(function (run) {
+        if (run.gap) {
+          L.polyline(run.points, { color: '#ffffff', weight: 5, opacity: 0.6, lineCap: 'round' }).addTo(map);
+          L.polyline(run.points, { color: '#ec4899', weight: 3, opacity: 0.95, dashArray: '10,8', lineCap: 'round' }).addTo(map);
+        } else {
+          L.polyline(run.points, { color: '#ffffff', weight: 5,   opacity: 0.7, lineJoin: 'round', lineCap: 'round' }).addTo(map);
+          L.polyline(run.points, { color: '#2563eb', weight: 2.5, opacity: 0.9, lineJoin: 'round', lineCap: 'round' }).addTo(map);
+        }
+      });
     });
   })();
   </script>

--- a/web/templates/trip_detail.html
+++ b/web/templates/trip_detail.html
@@ -379,9 +379,21 @@
         referrerPolicy: 'origin'
       }).addTo(map);
 
-      // Route: single red with white outline for visibility
-      L.polyline(latlngs, { color: '#ffffff', weight: 8, opacity: 0.7 }).addTo(map);
-      L.polyline(latlngs, { color: '#e63946', weight: 5, opacity: 1.0 }).addTo(map);
+      // Route: single red with white outline for visibility. A gap-bridge run (real signal
+      // loss — see db_reader._split_track_gaps) gets its own white casing too, then a bold
+      // magenta dash on top — a colour used nowhere else on this map (not the route red, not
+      // OSM's own grey/brown dashed tracks and borders), wide enough to read as a deliberate
+      // marking instead of blending into the base tiles.
+      const routeSegments = {{ trip.route_segments | tojson }};
+      routeSegments.forEach(function (run) {
+        if (run.gap) {
+          L.polyline(run.points, { color: '#ffffff', weight: 6, opacity: 0.6, lineCap: 'round' }).addTo(map);
+          L.polyline(run.points, { color: '#ec4899', weight: 3.5, opacity: 0.95, dashArray: '10,8', lineCap: 'round' }).addTo(map);
+        } else {
+          L.polyline(run.points, { color: '#ffffff', weight: 8, opacity: 0.7 }).addTo(map);
+          L.polyline(run.points, { color: '#e63946', weight: 5, opacity: 1.0 }).addTo(map);
+        }
+      });
 
       // Flag markers
       const flagIcon = (color, checkered) => L.divIcon({


### PR DESCRIPTION
EN
--
Every map (the global Map, the report's month map, a single trip's own map) joins recorded GPS fixes with a plain straight line — including across a genuine signal-loss stretch (a tunnel, a dead zone, a cloud hiccup), where that line cuts through whatever is actually there instead of following the road. There was no way to tell "the car really drove this straight line" from "we simply lost the signal here".

db_reader._split_track_gaps marks the difference: a jump much bigger than a trip's OWN typical sampling interval (median inter-sample delay × 3, floored at a minute so a fast poll rate can't have a real dropout hidden by its own tight cadence) becomes its own 2-point "gap" segment; the templates (map.html, report.html, trip_detail.html) draw it thin, dashed and muted, while every normal consecutive stretch keeps the current solid line. Same idea the trip-profile chart already applies to a gap in SoC/speed (left blank rather than joined) — extended to the map itself.

get_all_track/get_month_track (_rows_to_segments) now split each trip into these solid/gap runs BEFORE downsampling, so the existing max_points budget is spent per RUN (gap bridges are already just their 2 endpoints and are never thinned). A single trip's own map applies the same split without touching `trip.positions` itself — the SoC/speed chart and its cursor marker index that list 1:1, so it's read, never reshaped.

Verified against a real trip in the field with an 8-minute tunnel gap: the dashed bridge lands exactly there on the actual map, both on the trip's own page and on the general Map (24 such gaps across the whole history). 8 new tests (test_track_gap_segments.py) at the unit level (threshold math, chunking-vs-gap interaction, sqlite3.Row vs dict input) and through the real DB path.

CRITICAL / trade-offs
- The threshold is RELATIVE to each trip's own median interval, which is intentional (self-adjusts to whatever driving poll rate is configured) but means the SAME absolute jump can be a "gap" on one trip and normal cadence on another — a trip with only a couple of samples, or with very irregular polling throughout, has a shakier median and could occasionally misclassify a stretch either way. Not observed in the real data used to verify this; worth a second look if a trip ever shows an unexpected dashed segment on an otherwise unremarkable drive.
- get_all_track/get_month_track's return shape changed (a flat list of [lat,lon] polylines is now a list of {"points": [...], "gap": bool} runs per trip) — a deliberate breaking change to those two functions' contract. Two existing tests asserted the old flat shape and needed updating; anything OUTSIDE this repo reading that shape directly (none found) would need the same update.

IT
--
Ogni mappa (la Mappa generale, la mappa mensile del Report, la mappa del singolo viaggio) collega i punti GPS registrati con una semplice linea retta — anche attraverso un vero tratto di perdita di segnale (un tunnel, una zona senza copertura, un intoppo del cloud), dove quella linea attraversa qualunque cosa ci sia davvero invece di seguire la strada. Non c'era modo di distinguere "l'auto ha davvero percorso questa linea retta" da "qui abbiamo semplicemente perso il segnale".

db_reader._split_track_gaps segna la differenza: un salto molto più grande dell'intervallo di campionamento tipico DI QUEL viaggio (mediana dei ritardi tra campioni × 3, con un pavimento di un minuto perché un polling veloce non nasconda un vero buco dietro la propria cadenza stretta) diventa un segmento "gap" a sé di 2 punti; i template (map.html, report.html, trip_detail.html) lo disegnano sottile, tratteggiato e tenue, mentre ogni tratto normale consecutivo mantiene l'attuale linea solida. Stessa idea che il grafico del profilo di viaggio applica già a un buco in SoC/velocità (lasciato vuoto anziché unito) — estesa ora alla mappa stessa.

get_all_track/get_month_track (_rows_to_segments) ora dividono ogni viaggio in questi tratti solidi/gap PRIMA del downsampling, così il budget max_points esistente viene speso per singolo tratto (i ponti-gap sono già solo i loro 2 punti estremi e non vengono mai ulteriormente diradati). La mappa del singolo viaggio applica la stessa divisione senza toccare `trip.positions` in sé — il grafico SoC/velocità e il suo marcatore cursore indicizzano quella lista 1:1, quindi viene letta, mai rimodellata.

Verificato su un viaggio reale con un buco da tunnel di 8 minuti: il ponte tratteggiato compare esattamente lì sulla mappa vera, sia nella pagina del viaggio che sulla Mappa generale (24 buchi di questo tipo su tutta la cronologia). 8 nuovi test (test_track_gap_segments.py) a livello unitario (matematica della soglia, interazione chunking-vs-gap, input sqlite3.Row vs dict) e attraverso il percorso DB reale.

CRITICO / compromessi
- La soglia è RELATIVA alla mediana propria di ogni viaggio, il che è intenzionale (si auto-adatta a qualunque intervallo di polling in guida sia configurato) ma significa che lo STESSO salto assoluto può essere un "gap" su un viaggio e cadenza normale su un altro — un viaggio con solo pochi campioni, o con polling molto irregolare per tutta la sua durata, ha una mediana più instabile e potrebbe occasionalmente classificare male un tratto in un senso o nell'altro. Non osservato nei dati reali usati per verificare questo lavoro; da riguardare se mai un viaggio mostrasse un segmento tratteggiato inatteso su una guida altrimenti normale.
- La forma restituita da get_all_track/get_month_track è cambiata (una lista piatta di polilinee [lat,lon] è ora una lista di tratti {"points": [...], "gap": bool} per viaggio) — una modifica deliberatamente non retrocompatibile al contratto di queste due funzioni. Due test esistenti verificavano la vecchia forma piatta ed è stato necessario aggiornarli; qualunque cosa AL DI FUORI di questo repo che legga direttamente quella forma (nessuna trovata) richiederebbe lo stesso aggiornamento.