### PR TITLE
fix: recalculate and sync costs/types for all segments of a merged ch…

### DIFF
--- a/tests/test_merged_charges_cost_calculation.py
+++ b/tests/test_merged_charges_cost_calculation.py
@@ -1,0 +1,142 @@
+import sqlite3
+import pytest
+import db as poller_db
+import db_reader
+
+def _setup(tmp_path, monkeypatch):
+    path = str(tmp_path / "c.db")
+    poller_db.Database(path)
+    con = sqlite3.connect(path)
+    con.execute("INSERT INTO vehicles (id, vin) VALUES (1, 'V1')")
+    con.commit()
+    con.close()
+    monkeypatch.setattr(db_reader, "DB_PATH", path)
+    return path
+
+def _seed_charges(path):
+    con = sqlite3.connect(path)
+    # Piece A: 10 kWh energy, started at 12:00
+    # Piece B: 5 kWh energy, started at 12:30 (30 min pause)
+    for cid, s, e, ss, es, kwh in (
+        (1, "2026-08-12T12:00:00+00:00", "2026-08-12T12:20:00+00:00", 40.0, 50.0, 10.0),
+        (2, "2026-08-12T12:22:00+00:00", "2026-08-12T12:32:00+00:00", 50.0, 55.0, 5.0),
+    ):
+        con.execute(
+            "INSERT INTO charges (id, vehicle_id, started_at, ended_at, start_soc, end_soc, "
+            "energy_added_kwh, duration_min, charge_type, location_type, cost) "
+            "VALUES (?, 1, ?, ?, ?, ?, ?, 10.0, 'AC', NULL, NULL)",
+            (cid, s, e, ss, es, kwh))
+    con.commit()
+    con.close()
+
+def test_merged_charges_cost_recalculation(tmp_path, monkeypatch):
+    path = _setup(tmp_path, monkeypatch)
+    _seed_charges(path)
+
+    # Set up some pricing config: HOME flat rate = 0.20 EUR/kWh
+    monkeypatch.setattr(db_reader, "get_charge_prices", lambda: {"price_home_kwh": 0.20})
+    monkeypatch.setattr(db_reader, "get_cost_config", lambda: {"mode": "flat"})
+
+    # Merge them: 2 into 1
+    res = db_reader.merge_charges(1, 2)
+    assert res["ok"] is True
+
+    # Check that both are still unconfirmed with NULL cost
+    con = sqlite3.connect(path)
+    con.row_factory = sqlite3.Row
+    r1 = con.execute("SELECT * FROM charges WHERE id=1").fetchone()
+    r2 = con.execute("SELECT * FROM charges WHERE id=2").fetchone()
+    con.close()
+    assert r1["location_type"] is None
+    assert r1["cost"] is None
+    assert r2["location_type"] is None
+    assert r2["cost"] is None
+
+    # Now update type of the parent to HOME
+    db_reader.update_charge_type(1, "HOME")
+
+    # Check that BOTH charges are updated to HOME and costs are calculated
+    con = sqlite3.connect(path)
+    con.row_factory = sqlite3.Row
+    r1 = con.execute("SELECT * FROM charges WHERE id=1").fetchone()
+    r2 = con.execute("SELECT * FROM charges WHERE id=2").fetchone()
+    con.close()
+
+    assert r1["location_type"] == "HOME"
+    # Cost for 1: 10 kWh * 0.20 = 2.0 EUR
+    assert r1["cost"] == pytest.approx(2.0)
+
+    assert r2["location_type"] == "HOME"
+    # Cost for 2: 5 kWh * 0.20 = 1.0 EUR
+    assert r2["cost"] == pytest.approx(1.0)
+
+    # Check that displaying the merged group yields the correct total cost (3.0 EUR)
+    charges = db_reader.get_charges()
+    assert len(charges) == 1
+    assert charges[0]["cost"] == pytest.approx(3.0)
+
+def test_merged_charges_manual_cost(tmp_path, monkeypatch):
+    path = _setup(tmp_path, monkeypatch)
+    _seed_charges(path)
+
+    db_reader.merge_charges(1, 2)
+
+    # Update to MANUAL with a custom total cost of 4.50 EUR
+    db_reader.update_charge_type(1, "MANUAL", manual_cost=4.50)
+
+    con = sqlite3.connect(path)
+    con.row_factory = sqlite3.Row
+    r1 = con.execute("SELECT * FROM charges WHERE id=1").fetchone()
+    r2 = con.execute("SELECT * FROM charges WHERE id=2").fetchone()
+    con.close()
+
+    assert r1["location_type"] == "MANUAL"
+    assert r1["cost"] == pytest.approx(4.50)
+
+    assert r2["location_type"] == "MANUAL"
+    assert r2["cost"] is None
+
+    # Total displayed cost should be 4.50 EUR
+    charges = db_reader.get_charges()
+    assert len(charges) == 1
+    assert charges[0]["cost"] == pytest.approx(4.50)
+
+def test_merged_charges_gross_kwh_distribution(tmp_path, monkeypatch):
+    path = _setup(tmp_path, monkeypatch)
+    _seed_charges(path)
+
+    db_reader.merge_charges(1, 2)
+
+    # Set up flat price = 0.30 EUR/kWh
+    monkeypatch.setattr(db_reader, "get_charge_prices", lambda: {"price_home_kwh": 0.30})
+    monkeypatch.setattr(db_reader, "get_cost_config", lambda: {"mode": "flat"})
+
+    # We must confirm it first so set_charge_gross_kwh doesn't bail early
+    db_reader.update_charge_type(1, "HOME")
+
+    # Set gross_kwh = 30.0 kWh on the merged charge (parent is 1)
+    db_reader.set_charge_gross_kwh(1, 30.0)
+
+    # Check database:
+    # Total battery kwh = 10.0 + 5.0 = 15.0 kWh
+    # Proportion for 1: 10 / 15 = 2/3. So gross_kwh = 30.0 * 2/3 = 20.0 kWh.
+    # Proportion for 2: 5 / 15 = 1/3. So gross_kwh = 30.0 * 1/3 = 10.0 kWh.
+    # Cost for 1: 20.0 * 0.30 = 6.0 EUR
+    # Cost for 2: 10.0 * 0.30 = 3.0 EUR
+    con = sqlite3.connect(path)
+    con.row_factory = sqlite3.Row
+    r1 = con.execute("SELECT * FROM charges WHERE id=1").fetchone()
+    r2 = con.execute("SELECT * FROM charges WHERE id=2").fetchone()
+    con.close()
+
+    assert r1["gross_kwh"] == pytest.approx(20.0)
+    assert r1["cost"] == pytest.approx(6.0)
+
+    assert r2["gross_kwh"] == pytest.approx(10.0)
+    assert r2["cost"] == pytest.approx(3.0)
+
+    # Total group gross and cost
+    charges = db_reader.get_charges()
+    assert len(charges) == 1
+    assert charges[0]["gross_kwh"] == pytest.approx(30.0)
+    assert charges[0]["cost"] == pytest.approx(9.0)

--- a/web/db_reader.py
+++ b/web/db_reader.py
@@ -1880,6 +1880,14 @@ def update_charge_type(charge_id: int, location_type: str,
     else:
         db.execute("UPDATE charges SET location_type=?, cost=?, is_free=? WHERE id=?",
                    (location_type, cost, free, charge_id))
+
+    # Sync type, cost, free status, and gross_kwh for all pieces in the merged group
+    if _charges_have_merge(db):
+        parent_row = db.execute("SELECT id, merged_into_id FROM charges WHERE id=?", (charge_id,)).fetchone()
+        if parent_row:
+            parent_id = parent_row["merged_into_id"] or parent_row["id"]
+            _sync_charge_group_costs_and_types(db, parent_id, force_recalc=True)
+
     db.commit()
     return dict(db.execute("SELECT * FROM charges WHERE id=?", (charge_id,)).fetchone())
 
@@ -4033,6 +4041,82 @@ CHARGE_MERGE_GAP_DEFAULT = 30
 _CHARGE_MERGE_SOC_TOLERANCE = 2.0
 
 
+def _sync_charge_group_costs_and_types(db, parent_id: int, force_recalc: bool = False) -> None:
+    """Sync type, is_free, cost and gross_kwh across all pieces of a merged group.
+
+    If the parent is manual, parent keeps the manual cost and children get None.
+    If the parent has gross_kwh it is distributed proportionally to energy_added_kwh.
+    Otherwise, costs are computed individually for each piece based on its own energy/meter."""
+    parent_row = db.execute("SELECT * FROM charges WHERE id=?", (parent_id,)).fetchone()
+    if not parent_row:
+        return
+    parent = dict(parent_row)
+    location_type = parent.get("location_type")
+    is_free = parent.get("is_free") or 0
+    has_gross_col = _charges_have_gross(db)
+
+    # Find children
+    children = [dict(r) for r in db.execute(
+        "SELECT * FROM charges WHERE merged_into_id=?", (parent_id,)).fetchall()]
+
+    group = [parent] + children
+
+    if not location_type:
+        # Unconfirmed: clear cost and location_type for all
+        for c in group:
+            if c.get("location_type") is not None:
+                db.execute("UPDATE charges SET location_type=NULL, cost=NULL, is_free=0, gross_kwh=NULL WHERE id=?", (c["id"],))
+        return
+
+    if location_type == "MANUAL":
+        # MANUAL: parent keeps the manual cost, children get None
+        db.execute("UPDATE charges SET location_type='MANUAL', cost=?, is_free=0, gross_kwh=NULL WHERE id=?",
+                   (parent.get("cost"), parent["id"]))
+        for c in children:
+            db.execute("UPDATE charges SET location_type='MANUAL', cost=NULL, is_free=0, gross_kwh=NULL WHERE id=?", (c["id"],))
+        return
+
+    # For other types: distribute gross_kwh if parent has it
+    total_gross = parent.get("gross_kwh")
+
+    if total_gross is not None and total_gross > 0 and has_gross_col:
+        total_battery = sum((c.get("energy_added_kwh") or 0.0) for c in group)
+        for c in group:
+            share = (c.get("energy_added_kwh") or 0.0) / total_battery if total_battery > 0 else 1.0 / len(group)
+            c["gross_kwh"] = round(total_gross * share, 3)
+    else:
+        for c in group:
+            c["gross_kwh"] = None
+
+    # Recalculate cost for each piece if needed
+    for c in group:
+        if not force_recalc and c.get("location_type") == location_type and c.get("cost") is not None:
+            # Keep existing cost
+            continue
+
+        meter = c.get("ac_energy_kwh")
+        if location_type == "HOME" and meter and meter > 0:
+            billed = meter
+        elif c["gross_kwh"] and c["gross_kwh"] > 0:
+            billed = c["gross_kwh"]
+        else:
+            billed = None
+
+        temp_charge = {**c, "location_type": location_type, "is_free": is_free}
+        c["cost"] = compute_cost(temp_charge, ac_kwh=billed)
+
+    # Save to DB
+    for c in group:
+        c_gross = c.get("gross_kwh")
+        c_cost = c.get("cost")
+        if has_gross_col:
+            db.execute("UPDATE charges SET location_type=?, cost=?, is_free=?, gross_kwh=? WHERE id=?",
+                       (location_type, c_cost, is_free, c_gross, c["id"]))
+        else:
+            db.execute("UPDATE charges SET location_type=?, cost=?, is_free=? WHERE id=?",
+                       (location_type, c_cost, is_free, c["id"]))
+
+
 def merge_charges(parent_id: int, child_id: int, gap_min: int = CHARGE_MERGE_GAP_DEFAULT) -> dict:
     """Join two charge rows the car split by declaring the cable gone on a pause.
 
@@ -4086,6 +4170,7 @@ def merge_charges(parent_id: int, child_id: int, gap_min: int = CHARGE_MERGE_GAP
     # absorb B and any of B's own children into A, so every piece points at the parent
     db.execute("UPDATE charges SET merged_into_id=? WHERE id=? OR merged_into_id=?",
                (a["id"], b["id"], b["id"]))
+    _sync_charge_group_costs_and_types(db, a["id"], force_recalc=False)
     db.commit()
     return {"ok": True, "parent_id": a["id"]}
 


### PR DESCRIPTION
This PR fixes a bug on the **Charges** page where merging two or more charges resulted in an incorrect total cost once confirmed. 

#### The Bug
When a merged charge (consisting of a parent row and one or more child rows linked via `merged_into_id`) was confirmed or updated (e.g., set to `HOME` or `WORK`), `update_charge_type` was only executed on the parent row. 
As a result:
- Only the parent row had its `location_type` updated and its `cost` recalculated.
- The child rows in the database remained untagged (`location_type = NULL`) and unpriced (`cost = NULL`).
- When the page displayed the merged charge, the total cost (which is the sum of the group's pieces) only accounted for the parent's individual portion.

#### The Fix
- Created a helper function `_sync_charge_group_costs_and_types` to keep the entire merged group consistent:
  - Propagates `location_type` and `is_free` to all segments of the group.
  - Correctly recalculates individual costs for all pieces based on their respective portion of energy.
  - If a user enters a custom `gross_kwh` for the group, it distributes it proportionally to their battery energy (`energy_added_kwh`) before pricing each piece, avoiding double-counting in SQL `SUM` queries on unmigrated databases.
  - For `MANUAL` cost inputs, the total custom price is assigned to the parent while children's costs are set to `None` so they sum up correctly.
  - Safely guards queries using `_charges_have_merge` to prevent exceptions on databases that haven't run migration sweeps yet.
- Integrated the helper inside `update_charge_type` (forcing recalculation) and `merge_charges` (preserving existing costs).

### Test Coverage
Added a new test suite `tests/test_merged_charges_cost_calculation.py` covering:
1. `test_merged_charges_cost_recalculation`: Verifies that confirming a merged group recalculates costs on all segments and displays the correct sum.
2. `test_merged_charges_manual_cost`: Verifies manual cost entry works seamlessly on merged sessions.
3. `test_merged_charges_gross_kwh_distribution`: Verifies proportional distribution of manual gross kWh across pieces and correct cost weightings.