### PR TITLE
Refine dual range estimates styling and layout

### DIFF
--- a/tests/test_range_at_charge_target.py
+++ b/tests/test_range_at_charge_target.py
@@ -34,10 +34,12 @@ def test_missing_range_or_soc_gives_no_estimate(range_km, soc):
 
 
 def test_status_card_shows_the_target_not_a_fixed_100():
-    """The Overview card must read the target through the global and label it with the real %, not the
-    old hard-coded 'Estimated at 100%'."""
+    """The Overview card must read the target through the global and label it with the real %, never a
+    hard-coded percentage or a hard-coded language. It now shows the target AND 100% side by side
+    (range_estimates), which is the same promise: the number you plan around is the one you charge to."""
     import pathlib
     src = (pathlib.Path(db_reader.__file__).resolve().parent
-           / "templates" / "partials" / "status_card.html").read_text()
-    assert "range_at_charge_target(status.range_km" in src
-    assert "est.pct" in src and "range_est_100" not in src
+           / "templates" / "partials" / "status_card.html").read_text(encoding="utf-8")
+    assert "range_estimates(status.range_km" in src
+    assert "ests.limit_est.pct" in src            # the target %, read from the estimate — not a literal
+    assert "Stima al" not in src                  # labels come from the locale files, not the template

--- a/web/locales/de.json
+++ b/web/locales/de.json
@@ -496,6 +496,7 @@
     "battery": "Batterie",
     "range": "Reichweite",
     "range_est_at": "Schätzung bei {pct}%",
+    "range_est_100": "Schätzung bei 100%",
     "state": "Status",
     "speed": "Tempo",
     "gear": "Gang",

--- a/web/locales/en.json
+++ b/web/locales/en.json
@@ -496,6 +496,7 @@
     "battery": "Battery",
     "range": "Range",
     "range_est_at": "Estimated at {pct}%",
+    "range_est_100": "Estimated at 100%",
     "state": "State",
     "speed": "Speed",
     "gear": "Gear",

--- a/web/locales/es.json
+++ b/web/locales/es.json
@@ -496,6 +496,7 @@
     "battery": "Batería",
     "range": "Autonomía",
     "range_est_at": "Estimada al {pct} %",
+    "range_est_100": "Estimada al 100 %",
     "state": "Estado",
     "speed": "Velocidad",
     "gear": "Marcha",

--- a/web/locales/fr.json
+++ b/web/locales/fr.json
@@ -496,6 +496,7 @@
     "battery": "Batterie",
     "range": "Autonomie",
     "range_est_at": "Estimation à {pct} %",
+    "range_est_100": "Estimation à 100 %",
     "state": "État",
     "speed": "Vitesse",
     "gear": "Rapport",

--- a/web/locales/it.json
+++ b/web/locales/it.json
@@ -496,6 +496,7 @@
     "battery": "Batteria",
     "range": "Autonomia",
     "range_est_at": "Stima al {pct}%",
+    "range_est_100": "Stima al 100%",
     "state": "Stato",
     "speed": "Velocità",
     "gear": "Marcia",

--- a/web/locales/nl.json
+++ b/web/locales/nl.json
@@ -496,6 +496,7 @@
     "battery": "Batterij",
     "range": "Actieradius",
     "range_est_at": "Geschat bij {pct}%",
+    "range_est_100": "Geschat bij 100%",
     "state": "Status",
     "speed": "Snelheid",
     "gear": "Stand",

--- a/web/locales/pl.json
+++ b/web/locales/pl.json
@@ -496,6 +496,7 @@
     "battery": "Bateria",
     "range": "Zasięg",
     "range_est_at": "Szacunek przy {pct}%",
+    "range_est_100": "Szacunek przy 100%",
     "state": "Stan",
     "speed": "Prędkość",
     "gear": "Bieg",

--- a/web/locales/pt-PT.json
+++ b/web/locales/pt-PT.json
@@ -496,6 +496,7 @@
     "battery": "Bateria",
     "range": "Autonomia",
     "range_est_at": "Estimativa a {pct}%",
+    "range_est_100": "Estimativa a 100%",
     "state": "Estado",
     "speed": "Velocidade",
     "gear": "Mudança",

--- a/web/main.py
+++ b/web/main.py
@@ -276,6 +276,36 @@ def _range_at_charge_target(range_km, soc):
     return db_reader.range_at_charge_target(range_km, soc, limit)
 
 
+def _range_estimates(range_km, soc):
+    """Dual range estimates for the status card: at charge limit AND at 100%.
+    Returns a dict with:
+    - limit_est: estimate at the car's charge limit (dict with 'km' and 'pct')
+    - full_est: estimate at 100% (dict with 'km' and 'pct' = 100)
+    - show_both: boolean — True if limit is < 100 and should be shown separately, False otherwise
+    
+    Smart logic: if charge_limit is null or 100, show_both is False (avoid redundancy)."""
+    if range_km is None or not soc or soc <= 0:
+        return None
+    
+    vehicle, _ = db_reader.get_vehicle()
+    limit = _configured_charge_limit((vehicle or {}).get("vin") or "")
+    
+    # Always compute the estimate at 100%
+    full_est = db_reader.range_at_charge_target(range_km, soc, 100)
+    
+    # Compute estimate at limit
+    limit_est = db_reader.range_at_charge_target(range_km, soc, limit)
+    
+    # Show both only if limit is set and < 100
+    show_both = limit is not None and limit < 100
+    
+    return {
+        "limit_est": limit_est,
+        "full_est": full_est,
+        "show_both": show_both
+    }
+
+
 templates.env.globals.update(
     dist_unit=units.dist_unit, speed_unit=units.speed_unit, temp_unit=units.temp_unit,
     pressure_unit=units.pressure_unit, eff_unit=units.eff_unit, elev_unit=units.elev_unit,
@@ -298,6 +328,8 @@ templates.env.globals.update(
     absent_temps=db_reader.never_reported_temps,
     # #266 — the Overview range estimate, aimed at the car's charge target instead of a fixed 100%.
     range_at_charge_target=_range_at_charge_target,
+    # Dual estimates: at charge limit AND at 100%, with smart logic to avoid redundancy
+    range_estimates=_range_estimates,
 )
 app.mount("/static", StaticFiles(directory=str(Path(__file__).parent / "static")), name="static")
 

--- a/web/templates/partials/status_card.html
+++ b/web/templates/partials/status_card.html
@@ -2,6 +2,9 @@
 {% set soc = status.soc or 0 %}
 {% set color = soc_color(soc) %}
 {% set state = state_label(status) %}
+{# #266 — dual range estimates: at the car's charge limit AND at 100%. `show_both` is false when the
+   car charges to 100 (or hasn't reported a limit), so the two lines never repeat the same number. #}
+{% set ests = range_estimates(status.range_km, soc) %}
 
 <!-- SOC + Range -->
 <div class="mb-2">
@@ -13,11 +16,10 @@
     <div class="text-right flex flex-col">
       <div class="stat-label">{{ t('range') }}</div>
       <div class="stat-value text-4xl leading-none mt-1">{{ dist_val(status.range_km)|int }} <span class="text-base font-normal text-slate-400">{{ dist_unit() }}</span></div>
-      {% set ests = range_estimates(status.range_km, soc) %}
       {% if ests and not ests.show_both %}
         <!-- Single 100% estimate: show as before in the right column -->
         <div class="text-[11px] text-slate-400 leading-none mt-1">
-          Stima al <span class="font-bold">100</span>%: <span class="font-semibold text-teal-300">{{ dist_val(ests.full_est.km)|int }}</span> {{ dist_unit() }}
+          <span class="text-slate-400">{{ t('range_est_100') }}:</span> <span class="font-semibold text-teal-300">{{ dist_val(ests.full_est.km)|int }}</span> {{ dist_unit() }}
         </div>
       {% endif %}
     </div>
@@ -25,15 +27,14 @@
 </div>
 
 <!-- Range estimates above SOC bar: dual layout when limit < 100% -->
-{% set ests = range_estimates(status.range_km, soc) %}
 {% if ests and ests.show_both %}
   <!-- Left: estimate at limit%, Right: estimate at 100% -->
   <div class="grid grid-cols-2 gap-4 mb-2">
     <div class="text-left text-[11px] text-slate-400 leading-none">
-      Stima al <span class="font-bold">{{ ests.limit_est.pct|int }}</span>%: <span class="font-semibold text-teal-300">{{ dist_val(ests.limit_est.km)|int }}</span> {{ dist_unit() }}
+      {{ t('range_est_at').replace('{pct}', ests.limit_est.pct|int|string) }}: <span class="font-semibold text-teal-300">{{ dist_val(ests.limit_est.km)|int }}</span> {{ dist_unit() }}
     </div>
     <div class="text-right text-[11px] text-slate-400 leading-none">
-      Stima al <span class="font-bold">100</span>%: <span class="font-semibold text-teal-300">{{ dist_val(ests.full_est.km)|int }}</span> {{ dist_unit() }}
+      {{ t('range_est_100') }}: <span class="font-semibold text-teal-300">{{ dist_val(ests.full_est.km)|int }}</span> {{ dist_unit() }}
     </div>
   </div>
 {% endif %}

--- a/web/templates/partials/status_card.html
+++ b/web/templates/partials/status_card.html
@@ -4,41 +4,39 @@
 {% set state = state_label(status) %}
 
 <!-- SOC + Range -->
-<div class="mb-4">
+<div class="mb-2">
   <div class="grid grid-cols-2 items-start gap-4">
     <div class="text-left">
       <div class="stat-label">{{ t('battery') }}</div>
       <div class="text-5xl font-bold leading-none" style="color:{{ color }}">{{ soc|dec(1) }}<span class="text-2xl text-slate-400">%</span></div>
     </div>
-    <div class="text-right flex flex-col items-end">
+    <div class="text-right flex flex-col">
       <div class="stat-label">{{ t('range') }}</div>
-      <div class="stat-value leading-none mt-1">{{ dist_val(status.range_km)|int }} <span class="text-base font-normal text-slate-400">{{ dist_unit() }}</span></div>
+      <div class="stat-value text-4xl leading-none mt-1">{{ dist_val(status.range_km)|int }} <span class="text-base font-normal text-slate-400">{{ dist_unit() }}</span></div>
       {% set ests = range_estimates(status.range_km, soc) %}
-      {% if ests %}
-        {% if ests.show_both %}
-          <!-- Show both: estimate at limit (primary) and at 100% (secondary) -->
-          <div class="mt-0.5 text-[11px] leading-none">
-            <span class="text-slate-400">{{ t('range_est_at').replace('{pct}', ests.limit_est.pct|string) }}:</span>
-            <span class="font-semibold text-teal-300">{{ dist_val(ests.limit_est.km)|int }}</span>
-            <span class="text-slate-400">{{ dist_unit() }}</span>
-          </div>
-          <div class="mt-0.5 text-[10.5px] leading-none">
-            <span class="text-slate-400">{{ t('range_est_100') }}:</span>
-            <span class="font-normal text-teal-200">{{ dist_val(ests.full_est.km)|int }}</span>
-            <span class="text-slate-400">{{ dist_unit() }}</span>
-          </div>
-        {% else %}
-          <!-- Show only 100% estimate (no redundancy when limit is null or 100) -->
-          <div class="mt-0 text-[11px] leading-none">
-            <span class="text-slate-400">{{ t('range_est_100') }}:</span>
-            <span class="font-semibold text-teal-300">{{ dist_val(ests.full_est.km)|int }}</span>
-            <span class="text-slate-400">{{ dist_unit() }}</span>
-          </div>
-        {% endif %}
+      {% if ests and not ests.show_both %}
+        <!-- Single 100% estimate: show as before in the right column -->
+        <div class="text-[11px] text-slate-400 leading-none mt-1">
+          Stima al <span class="font-bold">100</span>%: <span class="font-semibold text-teal-300">{{ dist_val(ests.full_est.km)|int }}</span> {{ dist_unit() }}
+        </div>
       {% endif %}
     </div>
   </div>
 </div>
+
+<!-- Range estimates above SOC bar: dual layout when limit < 100% -->
+{% set ests = range_estimates(status.range_km, soc) %}
+{% if ests and ests.show_both %}
+  <!-- Left: estimate at limit%, Right: estimate at 100% -->
+  <div class="grid grid-cols-2 gap-4 mb-2">
+    <div class="text-left text-[11px] text-slate-400 leading-none">
+      Stima al <span class="font-bold">{{ ests.limit_est.pct|int }}</span>%: <span class="font-semibold text-teal-300">{{ dist_val(ests.limit_est.km)|int }}</span> {{ dist_unit() }}
+    </div>
+    <div class="text-right text-[11px] text-slate-400 leading-none">
+      Stima al <span class="font-bold">100</span>%: <span class="font-semibold text-teal-300">{{ dist_val(ests.full_est.km)|int }}</span> {{ dist_unit() }}
+    </div>
+  </div>
+{% endif %}
 
 <!-- SOC bar -->
 <div class="w-full bg-slate-700 rounded-full h-3 {% if battery_price is not none %}mb-1{% else %}mb-5{% endif %}">

--- a/web/templates/partials/status_card.html
+++ b/web/templates/partials/status_card.html
@@ -13,13 +13,28 @@
     <div class="text-right flex flex-col items-end">
       <div class="stat-label">{{ t('range') }}</div>
       <div class="stat-value leading-none mt-1">{{ dist_val(status.range_km)|int }} <span class="text-base font-normal text-slate-400">{{ dist_unit() }}</span></div>
-      {% set est = range_at_charge_target(status.range_km, soc) %}
-      {% if est %}
-      <div class="mt-0 text-[11px] leading-none">
-        <span class="text-slate-400">{{ t('range_est_at').replace('{pct}', est.pct|string) }}:</span>
-        <span class="font-semibold text-teal-300">{{ dist_val(est.km)|int }}</span>
-        <span class="text-slate-400">{{ dist_unit() }}</span>
-      </div>
+      {% set ests = range_estimates(status.range_km, soc) %}
+      {% if ests %}
+        {% if ests.show_both %}
+          <!-- Show both: estimate at limit (primary) and at 100% (secondary) -->
+          <div class="mt-0.5 text-[11px] leading-none">
+            <span class="text-slate-400">{{ t('range_est_at').replace('{pct}', ests.limit_est.pct|string) }}:</span>
+            <span class="font-semibold text-teal-300">{{ dist_val(ests.limit_est.km)|int }}</span>
+            <span class="text-slate-400">{{ dist_unit() }}</span>
+          </div>
+          <div class="mt-0.5 text-[10.5px] leading-none">
+            <span class="text-slate-400">{{ t('range_est_100') }}:</span>
+            <span class="font-normal text-teal-200">{{ dist_val(ests.full_est.km)|int }}</span>
+            <span class="text-slate-400">{{ dist_unit() }}</span>
+          </div>
+        {% else %}
+          <!-- Show only 100% estimate (no redundancy when limit is null or 100) -->
+          <div class="mt-0 text-[11px] leading-none">
+            <span class="text-slate-400">{{ t('range_est_100') }}:</span>
+            <span class="font-semibold text-teal-300">{{ dist_val(ests.full_est.km)|int }}</span>
+            <span class="text-slate-400">{{ dist_unit() }}</span>
+          </div>
+        {% endif %}
       {% endif %}
     </div>
   </div>


### PR DESCRIPTION
## Changes
Improved the range estimate display in the Overview card:

- **Dual estimate:** When a charge limit is set, the card now shows both the estimated range at your charge limit and at 100%
- **Single estimate:** When no charge limit is set or it's already 100%, only the 100% estimate is displayed to avoid redundancy