### PR TITLE
Log rejected MATE_FRAME_ANCESTORS entries, forgive a trailing slash, …

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,4 +11,10 @@ DB_PATH=leapmotor_mate.db
 # control. Comma-separated; each entry must be exactly scheme://host[:port] — no path, no
 # wildcards, ASCII only. Separate from MATE_TRUSTED_ORIGINS: an origin that may embed Mate is
 # not automatically one that may also submit write requests, and vice versa.
-# MATE_FRAME_ANCESTORS=https://hass.example.com
+#
+# Spell out the port if it isn't the scheme's default (80 for http, 443 for https) — a CSP
+# host-source with no port matches ONLY that default port, so a typical
+# http://homeassistant.local:8123 needs the :8123, or the embed is refused with no obvious
+# reason why. And note the browser enforces mixed content before any of this: an https://
+# dashboard can't frame a plain http:// Mate at all, whatever you put here.
+# MATE_FRAME_ANCESTORS=http://homeassistant.local:8123

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -171,6 +171,38 @@ def test_a_good_entry_survives_alongside_bad_ones(monkeypatch):
     assert headers["Content-Security-Policy"] == "frame-ancestors https://hass.example.com"
 
 
+def test_a_trailing_slash_from_the_address_bar_is_forgiven(monkeypatch):
+    """What a browser shows for a bare origin — copy it as-is and it still works, since that's
+    the single most likely way anyone pastes one in."""
+    monkeypatch.setenv("MATE_FRAME_ANCESTORS", "https://hass.example.com/")
+    headers = security.security_headers()
+    assert headers["Content-Security-Policy"] == "frame-ancestors https://hass.example.com"
+
+
+def test_a_slash_followed_by_an_actual_path_is_still_rejected(monkeypatch):
+    """The forgiveness above is for the bare trailing "/" only — a real path must still fail."""
+    monkeypatch.setenv("MATE_FRAME_ANCESTORS", "https://hass.example.com/lovelace/")
+    headers = security.security_headers()
+    assert "frame-ancestors 'none'" in headers["Content-Security-Policy"]
+
+
+def test_an_ipv6_literal_is_accepted(monkeypatch):
+    """CSP host-source syntax wants the brackets kept, same as a URL does."""
+    monkeypatch.setenv("MATE_FRAME_ANCESTORS", "http://[::1]:8123")
+    headers = security.security_headers()
+    assert headers["Content-Security-Policy"] == "frame-ancestors http://[::1]:8123"
+
+
+def test_a_rejected_entry_is_logged(monkeypatch, caplog):
+    """Silent used to mean untraceable: MATE_FRAME_ANCESTORS is set to something, the panel still
+    won't embed, and nothing says why. The web log (readable from Settings) now does."""
+    monkeypatch.setenv("MATE_FRAME_ANCESTORS", "https://hass.example.com/some/path")
+    with caplog.at_level("WARNING", logger="security"):
+        security.security_headers()
+    assert "MATE_FRAME_ANCESTORS" in caplog.text
+    assert "https://hass.example.com/some/path" in caplog.text
+
+
 def test_no_header_value_can_ever_break_latin1_encoding(monkeypatch):
     """What Starlette actually does when writing a response header out — this reproduces the
     crash a validation gap would cause, independent of whether fastapi/starlette are installed

--- a/web/security.py
+++ b/web/security.py
@@ -25,9 +25,12 @@ us, so every request legitimately carries HA's origin and HA frames the panel on
 Keeping either rule on would break the add-on UI for everyone while protecting nobody — ingress
 already authenticates, and it isn't reachable cross-origin without an HA session.
 """
+import logging
 import os
 import re
 from urllib.parse import urlsplit
+
+log = logging.getLogger(__name__)
 
 # Requests that can change something. GET/HEAD/OPTIONS are not checked: they must stay reachable
 # for the browser to render anything, and Mate has no state-changing GET.
@@ -53,26 +56,42 @@ SECURITY_HEADERS = {
 # in after the origin fails the match rather than riding along into the header. ASCII-only also
 # means a value that passes this can never fail the latin-1 encode Starlette does when it writes
 # the header out — that failure mode (a 500 on every response, /healthz included) is exactly what
-# unrestricted values risked before.
+# unrestricted values risked before. Host is a DNS name/IPv4, or an IPv6 literal in brackets
+# (e.g. https://[::1]:4000) — CSP host-source syntax requires the brackets there too.
 _FRAME_ANCESTOR_RE = re.compile(
     r"^https?://"
-    r"[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?"
+    r"(?:"
+    r"\[[0-9a-fA-F:]+\]"
+    r"|[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?"
     r"(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*"
+    r")"
     r"(?::[0-9]{1,5})?$"
 )
 
 
 def _valid_frame_ancestors() -> list[str]:
     """MATE_FRAME_ANCESTORS, split, stripped, and filtered to entries that are exactly
-    scheme://host[:port] — each rejected entry is dropped silently rather than passed through
-    (there is no reader to report a warning to), so a typo degrades to 'nothing configured', never
-    to 'whatever slipped past the regex'."""
+    scheme://host[:port]. A single trailing "/" is forgiven before checking — that's the bare
+    form a browser's address bar shows for an origin with no path, and rejecting it outright
+    would silently break the single most likely way to paste one in. Anything else malformed
+    (an actual path, a wildcard, a stray ";") is dropped and logged rather than passed through,
+    so a typo degrades to 'nothing configured, and it says why in the log', never to 'whatever
+    slipped past the regex'."""
     raw = os.environ.get("MATE_FRAME_ANCESTORS", "")
     seen: list[str] = []
     for entry in raw.split(","):
         entry = entry.strip()
-        if entry and _FRAME_ANCESTOR_RE.match(entry) and entry not in seen:
-            seen.append(entry)
+        if not entry:
+            continue
+        candidate = entry
+        if not _FRAME_ANCESTOR_RE.match(candidate) and candidate.endswith("/"):
+            candidate = candidate[:-1]
+        if _FRAME_ANCESTOR_RE.match(candidate):
+            if candidate not in seen:
+                seen.append(candidate)
+        else:
+            log.warning("MATE_FRAME_ANCESTORS: rejected %r — must be exactly "
+                        "scheme://host[:port], no path/query/wildcard", entry)
     return seen
 
 


### PR DESCRIPTION
…accept IPv6 literals

Three follow-ups from review, all left as non-blocking but easy to just do:

- A rejected entry used to vanish with no trace. log.warning() now names it and says why (matches the convention in crypto.py/charger_locator.py/main.py) — readable from Settings, so "I set the variable and it still won't embed" is diagnosable instead of a silent no-op.
- A single trailing "/" is forgiven before validating: that's the bare form a browser's address bar shows for an origin with no path, and rejecting the single most likely way to paste one in served nobody. An actual path still fails, trailing slash or not.
- Host now accepts a bracketed IPv6 literal (https://[::1]:4000), which CSP host-source syntax requires the brackets for too.

.env.example now spells out the port on its example (a CSP host-source with no port matches only the scheme's default) and notes that an https:// dashboard can't frame a plain http:// Mate regardless of any of this — mixed content, not a CSP question.